### PR TITLE
1060: oem-ibm: Add new file io completion code

### DIFF
--- a/include/libpldm/oem/ibm/libpldm/file_io.h
+++ b/include/libpldm/oem/ibm/libpldm/file_io.h
@@ -36,6 +36,7 @@ enum pldm_fileio_completion_codes {
 	PLDM_DATA_OUT_OF_RANGE = 0x87,
 	PLDM_INVALID_FILE_TYPE = 0x89,
 	PLDM_ERROR_FILE_DISCARDED = 0x8A,
+	PLDM_FULL_FILE_DISCARDED = 0x8B,
 };
 
 /** @brief PLDM File I/O table types

--- a/include/libpldm/oem/ibm/libpldm/pdr_oem_ibm.h
+++ b/include/libpldm/oem/ibm/libpldm/pdr_oem_ibm.h
@@ -25,7 +25,7 @@ pldm_pdr_record *pldm_pdr_find_last_local_record(const pldm_pdr *repo);
  *
  *  @param[in] record_handle - record handle of the pdr
  */
-bool isHBRange(const uint32_t record_handle);
+bool isHBRange(uint32_t record_handle);
 
 /** @brief find the container ID of the contained entity
  *

--- a/include/libpldm/pdr.h
+++ b/include/libpldm/pdr.h
@@ -457,7 +457,7 @@ uint16_t next_container_id(pldm_entity_association_tree *tree);
 pldm_entity_node *pldm_entity_association_tree_add(
 	pldm_entity_association_tree *tree, pldm_entity *entity,
 	uint16_t entity_instance_number, pldm_entity_node *parent,
-	uint8_t association_type, bool is_remote, bool is_update_contanier_id,
+	uint8_t association_type, bool is_remote, bool is_update_container_id,
 	uint16_t container_id);
 
 /** @brief deletes a node and it's children from the entity association tree
@@ -807,7 +807,7 @@ pldm_entity pldm_get_entity_from_record_handle(const pldm_pdr *repo,
  *  @param[in] association_type - association type
  */
 pldm_entity_node *init_pldm_entity_node(pldm_entity entity, pldm_entity parent,
-					uint16_t host_container_id,
+					uint16_t remote_container_id,
 					pldm_entity_node *first_child,
 					pldm_entity_node *next_sibling,
 					uint8_t association_type);

--- a/src/pdr.c
+++ b/src/pdr.c
@@ -441,12 +441,9 @@ int pldm_pdr_add_fru_record_set_check(pldm_pdr *repo, uint16_t terminus_handle,
 			prev_record_handle, fru->terminus_handle);
 
 		return 0;
-
-	} else {
-		return pldm_pdr_add_check(repo, data, size, false,
-					  fru->terminus_handle,
-					  bmc_record_handle);
 	}
+	return pldm_pdr_add_check(repo, data, size, false, fru->terminus_handle,
+				  bmc_record_handle);
 }
 
 LIBPLDM_ABI_STABLE
@@ -528,9 +525,9 @@ uint32_t pldm_pdr_remove_fru_record_set_by_rsi(pldm_pdr *repo, uint16_t fru_rsi,
 				}
 				free(record);
 				break;
-			} else {
-				prev = record;
 			}
+			prev = record;
+
 		} else {
 			prev = record;
 		}
@@ -658,9 +655,9 @@ void pldm_delete_by_record_handle(pldm_pdr *repo, uint32_t record_handle,
 			repo->size -= record->size;
 			free(record);
 			break;
-		} else {
-			prev = record;
 		}
+		prev = record;
+
 		record = next;
 	}
 }
@@ -868,9 +865,9 @@ uint16_t pldm_delete_by_effecter_id(pldm_pdr *repo, uint16_t effecter_id,
 				}
 				free(record);
 				break;
-			} else {
-				prev = record;
 			}
+			prev = record;
+
 		} else {
 			prev = record;
 		}
@@ -916,9 +913,9 @@ uint16_t pldm_delete_by_sensor_id(pldm_pdr *repo, uint16_t sensor_id,
 				}
 				free(record);
 				break;
-			} else {
-				prev = record;
 			}
+			prev = record;
+
 		} else {
 			prev = record;
 		}
@@ -1731,7 +1728,8 @@ uint32_t pldm_entity_association_pdr_remove_contained_entity(
 				}
 				free(record);
 				break;
-			} else if (removed) {
+			}
+			if (removed) {
 				if (repo->first == record) {
 					repo->first = new_record;
 					new_record->next = record->next;

--- a/tests/libpldm_platform_test.cpp
+++ b/tests/libpldm_platform_test.cpp
@@ -3255,21 +3255,21 @@ TEST(decodeNumericSensorPdrData, Uint8Test)
         0x1,
         0x0,
         0x0,
-        0x0,                     // record handle
-        0x1,                     // PDRHeaderVersion
-        PLDM_NUMERIC_SENSOR_PDR, // PDRType
+        0x0,                         // record handle
+        0x1,                         // PDRHeaderVersion
+        PLDM_NUMERIC_SENSOR_PDR,     // PDRType
         0x0,
-        0x0, // recordChangeNumber
+        0x0,                         // recordChangeNumber
         PLDM_PDR_NUMERIC_SENSOR_PDR_MIN_LENGTH,
-        0, // dataLength
+        0,                           // dataLength
         0,
-        0, // PLDMTerminusHandle
+        0,                           // PLDMTerminusHandle
         0x1,
-        0x0, // sensorID=1
+        0x0,                         // sensorID=1
         PLDM_ENTITY_POWER_SUPPLY,
-        0, // entityType=Power Supply(120)
+        0,                           // entityType=Power Supply(120)
         1,
-        0, // entityInstanceNumber
+        0,                           // entityInstanceNumber
         1,
         0,                           // containerID=1
         PLDM_NO_INIT,                // sensorInit
@@ -3294,12 +3294,12 @@ TEST(decodeNumericSensorPdrData, Uint8Test)
         0x80,
         0x3f, // offset=1.0
         0,
-        0, // accuracy
-        0, // plusTolerance
-        0, // minusTolerance
-        3, // hysteresis = 3
-        0, // supportedThresholds
-        0, // thresholdAndHysteresisVolatility
+        0,    // accuracy
+        0,    // plusTolerance
+        0,    // minusTolerance
+        3,    // hysteresis = 3
+        0,    // supportedThresholds
+        0,    // thresholdAndHysteresisVolatility
         0,
         0,
         0x80,
@@ -3384,19 +3384,19 @@ TEST(decodeNumericSensorPdrData, Sint8Test)
         0x1,                     // PDRHeaderVersion
         PLDM_NUMERIC_SENSOR_PDR, // PDRType
         0x0,
-        0x0, // recordChangeNumber
+        0x0,                     // recordChangeNumber
         PLDM_PDR_NUMERIC_SENSOR_PDR_FIXED_LENGTH +
             PLDM_PDR_NUMERIC_SENSOR_PDR_VARIED_SENSOR_DATA_SIZE_MIN_LENGTH +
             PLDM_PDR_NUMERIC_SENSOR_PDR_VARIED_RANGE_FIELD_MIN_LENGTH,
-        0, // dataLength
+        0,                             // dataLength
         0,
-        0, // PLDMTerminusHandle
+        0,                             // PLDMTerminusHandle
         0x1,
-        0x0, // sensorID=1
+        0x0,                           // sensorID=1
         PLDM_ENTITY_POWER_SUPPLY,
-        0, // entityType=Power Supply(120)
+        0,                             // entityType=Power Supply(120)
         1,
-        0, // entityInstanceNumber
+        0,                             // entityInstanceNumber
         0x1,
         0x0,                           // containerID=1
         PLDM_NO_INIT,                  // sensorInit
@@ -3480,19 +3480,19 @@ TEST(decodeNumericSensorPdrData, Uint16Test)
         0x1,                     // PDRHeaderVersion
         PLDM_NUMERIC_SENSOR_PDR, // PDRType
         0x0,
-        0x0, // recordChangeNumber
+        0x0,                     // recordChangeNumber
         PLDM_PDR_NUMERIC_SENSOR_PDR_FIXED_LENGTH +
             PLDM_PDR_NUMERIC_SENSOR_PDR_VARIED_SENSOR_DATA_SIZE_MIN_LENGTH * 2 +
             PLDM_PDR_NUMERIC_SENSOR_PDR_VARIED_RANGE_FIELD_MIN_LENGTH * 2,
-        0, // dataLength
+        0,                            // dataLength
         0,
-        0, // PLDMTerminusHandle
+        0,                            // PLDMTerminusHandle
         0x1,
-        0x0, // sensorID=1
+        0x0,                          // sensorID=1
         PLDM_ENTITY_POWER_SUPPLY,
-        0, // entityType=Power Supply(120)
+        0,                            // entityType=Power Supply(120)
         1,
-        0, // entityInstanceNumber
+        0,                            // entityInstanceNumber
         0x1,
         0x0,                          // containerID=1
         PLDM_NO_INIT,                 // sensorInit
@@ -3531,31 +3531,31 @@ TEST(decodeNumericSensorPdrData, Uint16Test)
         0,
         0,
         0x80,
-        0x3f, // updateInverval=1.0
+        0x3f,                           // updateInverval=1.0
         0,
-        0x10, // maxReadable = 4096
+        0x10,                           // maxReadable = 4096
         0,
         0,                              // minReadable = 0
         PLDM_RANGE_FIELD_FORMAT_UINT16, // rangeFieldFormat
         0,                              // rangeFieldsupport
         0x88,
-        0x13, // nominalValue = 5,000
+        0x13,                           // nominalValue = 5,000
         0x70,
-        0x17, // normalMax = 6,000
+        0x17,                           // normalMax = 6,000
         0xa0,
-        0x0f, // normalMin = 4,000
+        0x0f,                           // normalMin = 4,000
         0x58,
-        0x1b, // warningHigh = 7,000
+        0x1b,                           // warningHigh = 7,000
         0xb8,
-        0x0b, // warningLow = 3,000
+        0x0b,                           // warningLow = 3,000
         0x40,
-        0x1f, // criticalHigh = 8,000
+        0x1f,                           // criticalHigh = 8,000
         0xd0,
-        0x07, // criticalLow = 2,000
+        0x07,                           // criticalLow = 2,000
         0x28,
-        0x23, // fatalHigh = 9,000
+        0x23,                           // fatalHigh = 9,000
         0xe8,
-        0x03 // fatalLow = 1,000
+        0x03                            // fatalLow = 1,000
     };
 
     struct pldm_numeric_sensor_value_pdr decodedPdr;
@@ -3588,19 +3588,19 @@ TEST(decodeNumericSensorPdrData, Sint16Test)
         0x1,                     // PDRHeaderVersion
         PLDM_NUMERIC_SENSOR_PDR, // PDRType
         0x0,
-        0x0, // recordChangeNumber
+        0x0,                     // recordChangeNumber
         PLDM_PDR_NUMERIC_SENSOR_PDR_FIXED_LENGTH +
             PLDM_PDR_NUMERIC_SENSOR_PDR_VARIED_SENSOR_DATA_SIZE_MIN_LENGTH * 2 +
             PLDM_PDR_NUMERIC_SENSOR_PDR_VARIED_RANGE_FIELD_MIN_LENGTH * 2,
-        0, // dataLength
+        0,                            // dataLength
         0,
-        0, // PLDMTerminusHandle
+        0,                            // PLDMTerminusHandle
         0x1,
-        0x0, // sensorID=1
+        0x0,                          // sensorID=1
         PLDM_ENTITY_POWER_SUPPLY,
-        0, // entityType=Power Supply(120)
+        0,                            // entityType=Power Supply(120)
         1,
-        0, // entityInstanceNumber
+        0,                            // entityInstanceNumber
         0x1,
         0x0,                          // containerID=1
         PLDM_NO_INIT,                 // sensorInit
@@ -3639,31 +3639,31 @@ TEST(decodeNumericSensorPdrData, Sint16Test)
         0,
         0,
         0x80,
-        0x3f, // updateInverval=1.0
+        0x3f,                           // updateInverval=1.0
         0xe8,
-        0x03, // maxReadable = 1000
+        0x03,                           // maxReadable = 1000
         0x18,
         0xfc,                           // minReadable = -1000
         PLDM_RANGE_FIELD_FORMAT_SINT16, // rangeFieldFormat
         0,                              // rangeFieldsupport
         0,
-        0, // nominalValue = 0
+        0,                              // nominalValue = 0
         0xf4,
-        0x01, // normalMax = 500
+        0x01,                           // normalMax = 500
         0x0c,
-        0xfe, // normalMin = -500
+        0xfe,                           // normalMin = -500
         0xe8,
-        0x03, // warningHigh = 1,000
+        0x03,                           // warningHigh = 1,000
         0x18,
-        0xfc, // warningLow = -1,000
+        0xfc,                           // warningLow = -1,000
         0xd0,
-        0x07, // criticalHigh = 2,000
+        0x07,                           // criticalHigh = 2,000
         0x30,
-        0xf8, // criticalLow = -2,000
+        0xf8,                           // criticalLow = -2,000
         0xb8,
-        0x0b, // fatalHigh = 3,000
+        0x0b,                           // fatalHigh = 3,000
         0x48,
-        0xf4 // fatalLow = -3,000
+        0xf4                            // fatalLow = -3,000
     };
 
     struct pldm_numeric_sensor_value_pdr decodedPdr;
@@ -3696,19 +3696,19 @@ TEST(decodeNumericSensorPdrData, Uint32Test)
         0x1,                     // PDRHeaderVersion
         PLDM_NUMERIC_SENSOR_PDR, // PDRType
         0x0,
-        0x0, // recordChangeNumber
+        0x0,                     // recordChangeNumber
         PLDM_PDR_NUMERIC_SENSOR_PDR_FIXED_LENGTH +
             PLDM_PDR_NUMERIC_SENSOR_PDR_VARIED_SENSOR_DATA_SIZE_MIN_LENGTH * 4 +
             PLDM_PDR_NUMERIC_SENSOR_PDR_VARIED_RANGE_FIELD_MIN_LENGTH * 4,
-        0, // dataLength
+        0,                            // dataLength
         0,
-        0, // PLDMTerminusHandle
+        0,                            // PLDMTerminusHandle
         0x1,
-        0x0, // sensorID=1
+        0x0,                          // sensorID=1
         PLDM_ENTITY_POWER_SUPPLY,
-        0, // entityType=Power Supply(120)
+        0,                            // entityType=Power Supply(120)
         1,
-        0, // entityInstanceNumber
+        0,                            // entityInstanceNumber
         0x1,
         0x0,                          // containerID=1
         PLDM_NO_INIT,                 // sensorInit
@@ -3828,19 +3828,19 @@ TEST(decodeNumericSensorPdrData, Sint32Test)
         0x1,                     // PDRHeaderVersion
         PLDM_NUMERIC_SENSOR_PDR, // PDRType
         0x0,
-        0x0, // recordChangeNumber
+        0x0,                     // recordChangeNumber
         PLDM_PDR_NUMERIC_SENSOR_PDR_FIXED_LENGTH +
             PLDM_PDR_NUMERIC_SENSOR_PDR_VARIED_SENSOR_DATA_SIZE_MIN_LENGTH * 4 +
             PLDM_PDR_NUMERIC_SENSOR_PDR_VARIED_RANGE_FIELD_MIN_LENGTH * 4,
-        0, // dataLength
+        0,                            // dataLength
         0,
-        0, // PLDMTerminusHandle
+        0,                            // PLDMTerminusHandle
         0x1,
-        0x0, // sensorID=1
+        0x0,                          // sensorID=1
         PLDM_ENTITY_POWER_SUPPLY,
-        0, // entityType=Power Supply(120)
+        0,                            // entityType=Power Supply(120)
         1,
-        0, // entityInstanceNumber
+        0,                            // entityInstanceNumber
         0x1,
         0x0,                          // containerID=1
         PLDM_NO_INIT,                 // sensorInit
@@ -3960,19 +3960,19 @@ TEST(decodeNumericSensorPdrData, Real32Test)
         0x1,                     // PDRHeaderVersion
         PLDM_NUMERIC_SENSOR_PDR, // PDRType
         0x0,
-        0x0, // recordChangeNumber
+        0x0,                     // recordChangeNumber
         PLDM_PDR_NUMERIC_SENSOR_PDR_FIXED_LENGTH +
             PLDM_PDR_NUMERIC_SENSOR_PDR_VARIED_SENSOR_DATA_SIZE_MIN_LENGTH * 4 +
             PLDM_PDR_NUMERIC_SENSOR_PDR_VARIED_RANGE_FIELD_MIN_LENGTH * 4,
-        0, // dataLength
+        0,                            // dataLength
         0,
-        0, // PLDMTerminusHandle
+        0,                            // PLDMTerminusHandle
         0x1,
-        0x0, // sensorID=1
+        0x0,                          // sensorID=1
         PLDM_ENTITY_POWER_SUPPLY,
-        0, // entityType=Power Supply(120)
+        0,                            // entityType=Power Supply(120)
         1,
-        0, // entityInstanceNumber
+        0,                            // entityInstanceNumber
         0x1,
         0x0,                          // containerID=1
         PLDM_NO_INIT,                 // sensorInit
@@ -4089,21 +4089,21 @@ TEST(decodeNumericSensorPdrDataDeathTest, InvalidSizeTest)
         0x1,
         0x0,
         0x0,
-        0x0,                     // record handle
-        0x1,                     // PDRHeaderVersion
-        PLDM_NUMERIC_SENSOR_PDR, // PDRType
+        0x0,                         // record handle
+        0x1,                         // PDRHeaderVersion
+        PLDM_NUMERIC_SENSOR_PDR,     // PDRType
         0x0,
-        0x0, // recordChangeNumber
+        0x0,                         // recordChangeNumber
         PLDM_PDR_NUMERIC_SENSOR_PDR_FIXED_LENGTH,
-        0, // dataLength
+        0,                           // dataLength
         0,
-        0, // PLDMTerminusHandle
+        0,                           // PLDMTerminusHandle
         0x1,
-        0x0, // sensorID=1
+        0x0,                         // sensorID=1
         PLDM_ENTITY_POWER_SUPPLY,
-        0, // entityType=Power Supply(120)
+        0,                           // entityType=Power Supply(120)
         1,
-        0, // entityInstanceNumber
+        0,                           // entityInstanceNumber
         0x1,
         0x0,                         // containerID=1
         PLDM_NO_INIT,                // sensorInit

--- a/tests/libpldm_utils_test.cpp
+++ b/tests/libpldm_utils_test.cpp
@@ -78,7 +78,7 @@ TEST(BcdConversion, BcdCoversion)
 TEST(TimeLegal, TimeLegal)
 {
     EXPECT_EQ(true, is_time_legal(30, 25, 16, 18, 8, 2019));
-    EXPECT_EQ(true, is_time_legal(30, 25, 16, 29, 2, 2020)); // leap year
+    EXPECT_EQ(true, is_time_legal(30, 25, 16, 29, 2, 2020));   // leap year
 
     EXPECT_EQ(false, is_time_legal(30, 25, 16, 18, 8, 1960));  // year illegal
     EXPECT_EQ(false, is_time_legal(30, 25, 16, 18, 15, 2019)); // month illegal


### PR DESCRIPTION
#### oem-ibm: Add new file io completion code
```
The IBM hypervisor sends 0x8B meaning 'full file discarded' when it
doesn't have room to store a file.  In this case specifically it's for
when they are receiving event logs from the BMC.

Change-Id: I21cf1cd4c7034237d47d3855397627712bb2fe17
Signed-off-by: Matt Spinler <spinler@us.ibm.com>
```