### PR TITLE
libpldm: Stabilizing pldm_close()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ Change categories:
 
 ### Changed
 
-1. requester: Mark pldm_close() as LIBPLDM_ABI_TESTING
-2. requester: Expose pldm_close() in header
+1. requester: Stabilize pldm_close()
+2. transport: Stabilize pldm_transport_mctp_demux_destroy()
+3. requester: Expose pldm_close() in header
 
 ### Removed
 

--- a/src/requester/pldm.c
+++ b/src/requester/pldm.c
@@ -178,7 +178,7 @@ pldm_requester_rc_t pldm_send(mctp_eid_t eid, int mctp_fd,
 
 /* Adding this here for completeness in the case we can't smoothly
  * transition apps over to the new api */
-LIBPLDM_ABI_TESTING
+LIBPLDM_ABI_STABLE
 void pldm_close(void)
 {
 	if (open_transport) {

--- a/src/transport/mctp-demux.c
+++ b/src/transport/mctp-demux.c
@@ -230,7 +230,7 @@ int pldm_transport_mctp_demux_init(struct pldm_transport_mctp_demux **ctx)
 	return 0;
 }
 
-LIBPLDM_ABI_TESTING
+LIBPLDM_ABI_STABLE
 void pldm_transport_mctp_demux_destroy(struct pldm_transport_mctp_demux *ctx)
 {
 	if (!ctx) {


### PR DESCRIPTION
Changing ABI visibility from TESTING to
STABLE for a requester API pldm_close()
which uses pldm_transport_mctp_demux_destroy(),
a transport API whose visibility is also
changed likewise.

Use of pldm_close is demonstrated here-
https://gerrit.openbmc.org/c/openbmc/openpower-occ-control/+/66800

Tested: Error injection did not result in any 
pldm_send() failure

