### PR TITLE
oem-ibm: Moved the Real SAI entity id

### DIFF
--- a/include/libpldm/oem/ibm/libpldm/entity_oem_ibm.h
+++ b/include/libpldm/oem/ibm/libpldm/entity_oem_ibm.h
@@ -8,6 +8,7 @@ extern "C" {
 enum pldm_oem_ibm_entity_id_codes {
 	PLDM_OEM_IBM_ENTITY_TPM = 24576,
 	PLDM_OEM_IBM_ENTITY_FIRMWARE_UPDATE = 24577,
+	PLDM_OEM_IBM_ENTITY_REAL_SAI = 24581,
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
This commit moves the Real SAI (System Attention Indicator) oem entity id from pldm to libpldm.

Real SAI is a physical led indicator which lights up whenever there is a platform error (originated from BMC) or a partition error that is not mapped to any physical FRU (Field Replaceable Unit).

New change has been tested good with platform and partition error scenarios.

Change-Id: Ic62b4263ed09349a82a8d3e8580d9d19521cdf75