### PR TITLE
pdr: Check if RSI of a FRU record matches given RSI

### DIFF
--- a/include/libpldm/pdr.h
+++ b/include/libpldm/pdr.h
@@ -391,6 +391,18 @@ const pldm_pdr_record *pldm_pdr_fru_record_set_find_by_rsi(
 uint32_t pldm_pdr_remove_fru_record_set_by_rsi(pldm_pdr *repo, uint16_t fru_rsi,
 					       bool is_remote);
 
+/** @brief checks if the FRU record set idetifier of a record matches the give record set identifier
+ *
+ *  @param[in] record - opaque pointer acting as a PDR record handle
+ *  @param[in] rsi - FRU record set identifier
+ *  @param[in-out] match - boolean value to indicate if the given rsi matches the FRU record rsi
+ *
+ *  @return 0 on success, -EINVAL if the arguments are invalid, -ENOMEM if an internal memory
+ *  allocation fails, or -EOVERFLOW if a record handle could not be allocated
+ */
+int pldm_pdr_record_check_fru_rsi_match(const pldm_pdr_record *record,
+                                        uint16_t rsi, bool *match);
+
 /* =========================== */
 /* Entity Association PDR APIs */
 /* =========================== */

--- a/src/pdr.c
+++ b/src/pdr.c
@@ -378,6 +378,48 @@ uint32_t pldm_pdr_get_record_count(const pldm_pdr *repo)
 }
 
 LIBPLDM_ABI_STABLE
+int pldm_pdr_record_check_fru_rsi_match(const pldm_pdr_record *record,
+                                        uint16_t rsi, bool *match)
+{
+        if (!record) {
+                return -EINVAL;
+        }
+        uint16_t *record_fru_rsi = NULL;
+        int rc = 0;
+
+        struct pldm_msgbuf _dst;
+        struct pldm_msgbuf *dst = &_dst;
+
+        rc = pldm_msgbuf_init(
+                dst, sizeof(uint16_t),
+                (record->data + sizeof(struct pldm_pdr_hdr) + sizeof(uint16_t)),
+                record->size);
+        if (rc) {
+                printf("init error rc = %d\n", rc);
+                return rc;
+        }
+        rc = pldm_msgbuf_span_required(dst, sizeof(uint16_t),
+                                       (void **)(&record_fru_rsi));
+        if (rc) {
+                printf("span error rc = %d\n", rc);
+                return rc;
+        }
+
+        rc = pldm_msgbuf_destroy(dst);
+        if (rc) {
+                printf("destroy error rc = %d\n", rc);
+                return rc;
+        }
+
+        if (*record_fru_rsi == rsi) {
+                *match = true;
+        } else {
+                *match = false;
+        }
+        return 0;
+}
+
+LIBPLDM_ABI_STABLE
 uint32_t pldm_pdr_get_repo_size(const pldm_pdr *repo)
 {
 	assert(repo != NULL);

--- a/tests/libpldm_pdr_test.cpp
+++ b/tests/libpldm_pdr_test.cpp
@@ -2112,3 +2112,36 @@ TEST(EntityAssociationPDR, findAndAddHostPDR)
 
     pldm_entity_association_tree_destroy(tree);
 }
+
+TEST(PDRUpdate, testFruRecordRsiMatch)
+{
+    auto repo = pldm_pdr_init();
+    uint32_t record_handle = 1;
+    bool match = false;
+
+    EXPECT_EQ(pldm_pdr_add_fru_record_set_check(repo, 1, 1, 1, 0, 100,
+                                                &record_handle, false),
+              0);
+    record_handle = 2;
+    EXPECT_EQ(pldm_pdr_add_fru_record_set_check(repo, 1, 2, 1, 1, 100,
+                                                &record_handle, false),
+              0);
+    record_handle = 3;
+    EXPECT_EQ(pldm_pdr_add_fru_record_set_check(repo, 1, 3, 1, 2, 100,
+                                                &record_handle, false),
+              0);
+
+    uint16_t terminusHdl{};
+    uint16_t entityType{};
+    uint16_t entityInstanceNum{};
+    uint16_t containerId{};
+    auto record = pldm_pdr_fru_record_set_find_by_rsi(
+        repo, 2, &terminusHdl, &entityType, &entityInstanceNum, &containerId,
+        false);
+    EXPECT_NE(record, nullptr);
+
+    EXPECT_EQ(pldm_pdr_record_check_fru_rsi_match(record, 2, &match), 0);
+    EXPECT_EQ(match, true);
+
+    pldm_pdr_destroy(repo);
+}


### PR DESCRIPTION
API added to check if the record set identifier of a given FRU record matches the given record set identifier. This API can be used to find a particular FRU record from a PDR repo after the records are narrowed down using the required PDR type.