### PR TITLE
pdr: PDR loop fix

### DIFF
--- a/src/dsp/pdr.c
+++ b/src/dsp/pdr.c
@@ -828,14 +828,14 @@ bool pldm_is_current_parent_child(pldm_entity_node *parent, pldm_entity *node)
 static int entity_association_pdr_add_children(
 	pldm_entity_node *curr, pldm_pdr *repo, uint16_t size,
 	uint8_t contained_count, uint8_t association_type, bool is_remote,
-	uint16_t terminus_handle, uint32_t record_handle)
+	uint16_t terminus_handle, uint32_t *record_handle)
 {
 	uint8_t pdr[size];
 	uint8_t *start = pdr;
 
 	struct pldm_pdr_hdr *hdr = (struct pldm_pdr_hdr *)start;
 	hdr->version = 1;
-	hdr->record_handle = record_handle;
+	hdr->record_handle = *record_handle;
 	hdr->type = PLDM_PDR_ENTITY_ASSOCIATION;
 	hdr->record_change_num = 0;
 	hdr->length = htole16(size - sizeof(struct pldm_pdr_hdr));
@@ -871,13 +871,13 @@ static int entity_association_pdr_add_children(
 	}
 
 	return pldm_pdr_add_check(repo, pdr, size, is_remote, terminus_handle,
-				  &record_handle);
+				  record_handle);
 }
 
 static int entity_association_pdr_add_entry(pldm_entity_node *curr,
 					    pldm_pdr *repo, bool is_remote,
 					    uint16_t terminus_handle,
-					    uint32_t record_handle)
+					    uint32_t *record_handle)
 {
 	uint8_t num_logical_children = pldm_entity_get_num_children(
 		curr, PLDM_ENTITY_ASSOCIAION_LOGICAL);
@@ -898,6 +898,7 @@ static int entity_association_pdr_add_entry(pldm_entity_node *curr,
 		if (rc < 0) {
 			return rc;
 		}
+		*record_handle += 1;
 	}
 
 	if (num_physical_children) {
@@ -909,12 +910,11 @@ static int entity_association_pdr_add_entry(pldm_entity_node *curr,
 		rc = entity_association_pdr_add_children(
 			curr, repo, physical_pdr_size, num_physical_children,
 			PLDM_ENTITY_ASSOCIAION_PHYSICAL, is_remote,
-			terminus_handle,
-			((num_logical_children > 0) ? (record_handle + 1) :
-						      record_handle));
+			terminus_handle, record_handle);
 		if (rc < 0) {
 			return rc;
 		}
+		*record_handle += 1;
 	}
 
 	return 0;
@@ -940,12 +940,15 @@ static int entity_association_pdr_add(pldm_entity_node *curr, pldm_pdr *repo,
 				      pldm_entity **entities,
 				      size_t num_entities, bool is_remote,
 				      uint16_t terminus_handle,
-				      uint32_t record_handle)
+				      uint32_t *record_handle)
 {
 	int rc;
 
 	if (curr == NULL) {
 		return 0;
+	}
+	if (!record_handle) {
+		return -EINVAL;
 	}
 
 	if (is_present(curr->entity, entities, num_entities)) {
@@ -976,9 +979,9 @@ int pldm_entity_association_pdr_add_check(pldm_entity_association_tree *tree,
 	if (!tree || !repo) {
 		return 0;
 	}
-
+	uint32_t record_handle = 0;
 	return entity_association_pdr_add(tree->root, repo, NULL, 0, is_remote,
-					  terminus_handle, 0);
+					  terminus_handle, &record_handle);
 }
 
 LIBPLDM_ABI_STABLE
@@ -1002,7 +1005,7 @@ int pldm_entity_association_pdr_add_from_node_with_record_handle(
 	}
 
 	entity_association_pdr_add(node, repo, entities, num_entities,
-				   is_remote, terminus_handle, record_handle);
+				   is_remote, terminus_handle, &record_handle);
 
 	return 0;
 }

--- a/tests/dsp/pdr.cpp
+++ b/tests/dsp/pdr.cpp
@@ -1121,7 +1121,7 @@ TEST(EntityAssociationPDR, testSpecialTrees)
     pldm_entity_association_tree_destroy(tree);
 }
 
-/*TEST(EntityAssociationPDR, testPDR)
+TEST(EntityAssociationPDR, testPDR)
 {
     // e = entity type, c = container id, i = instance num
 
@@ -1425,7 +1425,7 @@ TEST(EntityAssociationPDR, testSpecialTrees)
 
     pldm_pdr_destroy(repo);
     pldm_entity_association_tree_destroy(tree);
-}*/
+}
 
 TEST(EntityAssociationPDR, testFind)
 {


### PR DESCRIPTION
While creating the Entity association PDRs, same record handle is used multiple time to create PDR. Because of which 2 PDRs with same record handle are added to the repo. Adding the fix to resolve the duplicate record handle issue.

Tested:
Power on/off and reset reload on mex and non mex systems.