### PR TITLE
pdr: support to get the entity using record handle

### DIFF
--- a/abi/x86_64/gcc.dump
+++ b/abi/x86_64/gcc.dump
@@ -4349,17 +4349,17 @@ $VAR1 = {
                                          'Return' => '100',
                                          'ShortName' => 'encode_get_fru_record_table_metadata_req'
                                        },
-                            '56558' => {
+                            '57494' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '543',
+                                         'Line' => '553',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '63024'
+                                                               'type' => '63960'
                                                              },
                                                       '1' => {
                                                                'name' => 'entity',
-                                                               'type' => '63029'
+                                                               'type' => '63965'
                                                              },
                                                       '2' => {
                                                                'name' => 'is_remote',
@@ -4373,17 +4373,17 @@ $VAR1 = {
                                          'Return' => '100',
                                          'ShortName' => 'pldm_entity_association_pdr_remove_contained_entity'
                                        },
-                            '65072' => {
+                            '66008' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '558',
+                                         'Line' => '568',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '66898'
+                                                               'type' => '67834'
                                                              },
                                                       '1' => {
                                                                'name' => 'parent',
-                                                               'type' => '63029'
+                                                               'type' => '63965'
                                                              },
                                                       '2' => {
                                                                'name' => 'is_remote',
@@ -4395,7 +4395,7 @@ $VAR1 = {
                                                              },
                                                       '4' => {
                                                                'name' => 'found',
-                                                               'type' => '66903'
+                                                               'type' => '67839'
                                                              }
                                                     },
                                          'Reg' => {
@@ -4407,13 +4407,13 @@ $VAR1 = {
                                          'Return' => '100',
                                          'ShortName' => 'pldm_entity_association_find_parent_entity'
                                        },
-                            '66908' => {
+                            '67844' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '729',
+                                         'Line' => '739',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '63024'
+                                                               'type' => '63960'
                                                              },
                                                       '1' => {
                                                                'name' => 'fru_rsi',
@@ -4437,13 +4437,13 @@ $VAR1 = {
                                          'Return' => '100',
                                          'ShortName' => 'pldm_pdr_remove_fru_record_set_by_rsi'
                                        },
-                            '68906' => {
+                            '69842' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '717',
+                                         'Line' => '727',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '63024'
+                                                               'type' => '63960'
                                                              },
                                                       '1' => {
                                                                'name' => 'sensor_id',
@@ -4457,13 +4457,13 @@ $VAR1 = {
                                          'Return' => '1011',
                                          'ShortName' => 'pldm_delete_by_sensor_id'
                                        },
-                            '69271' => {
+                            '70207' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '708',
+                                         'Line' => '718',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '63024'
+                                                               'type' => '63960'
                                                              },
                                                       '1' => {
                                                                'name' => 'effecter_id',
@@ -4477,13 +4477,13 @@ $VAR1 = {
                                          'Return' => '1011',
                                          'ShortName' => 'pldm_delete_by_effecter_id'
                                        },
-                            '69652' => {
+                            '70588' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '527',
+                                         'Line' => '537',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '63024'
+                                                               'type' => '63960'
                                                              },
                                                       '1' => {
                                                                'name' => 'pdr_record_handle',
@@ -4491,11 +4491,11 @@ $VAR1 = {
                                                              },
                                                       '2' => {
                                                                'name' => 'parent',
-                                                               'type' => '63029'
+                                                               'type' => '63965'
                                                              },
                                                       '3' => {
                                                                'name' => 'entity',
-                                                               'type' => '63029'
+                                                               'type' => '63965'
                                                              },
                                                       '4' => {
                                                                'name' => 'entity_record_handle',
@@ -4505,17 +4505,17 @@ $VAR1 = {
                                          'Return' => '100',
                                          'ShortName' => 'pldm_entity_association_pdr_create_new'
                                        },
-                            '74441' => {
+                            '75377' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '511',
+                                         'Line' => '521',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '63024'
+                                                               'type' => '63960'
                                                              },
                                                       '1' => {
                                                                'name' => 'entity',
-                                                               'type' => '63029'
+                                                               'type' => '63965'
                                                              },
                                                       '2' => {
                                                                'name' => 'pdr_record_handle',
@@ -4525,9 +4525,9 @@ $VAR1 = {
                                          'Return' => '100',
                                          'ShortName' => 'pldm_entity_association_pdr_add_contained_entity_to_remote_pdr'
                                        },
-                            '81956' => {
+                            '82892' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '698',
+                                         'Line' => '708',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'pdr',
@@ -4543,7 +4543,7 @@ $VAR1 = {
                                                              },
                                                       '3' => {
                                                                'name' => 'entities',
-                                                               'type' => '82269'
+                                                               'type' => '83205'
                                                              }
                                                     },
                                          'Reg' => {
@@ -4553,13 +4553,13 @@ $VAR1 = {
                                          'Return' => '1',
                                          'ShortName' => 'pldm_entity_association_pdr_extract'
                                        },
-                            '82279' => {
+                            '83215' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '686',
+                                         'Line' => '696',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'tree',
-                                                               'type' => '82328'
+                                                               'type' => '83264'
                                                              }
                                                     },
                                          'Reg' => {
@@ -4568,13 +4568,13 @@ $VAR1 = {
                                          'Return' => '805',
                                          'ShortName' => 'pldm_is_empty_entity_assoc_tree'
                                        },
-                            '82333' => {
+                            '83269' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '676',
+                                         'Line' => '686',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'tree',
-                                                               'type' => '82328'
+                                                               'type' => '83264'
                                                              }
                                                     },
                                          'Reg' => {
@@ -4583,65 +4583,65 @@ $VAR1 = {
                                          'Return' => '1',
                                          'ShortName' => 'pldm_entity_association_tree_destroy_root'
                                        },
-                            '82396' => {
+                            '83332' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '666',
+                                         'Line' => '676',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'org_tree',
-                                                               'type' => '82328'
+                                                               'type' => '83264'
                                                              },
                                                       '1' => {
                                                                'name' => 'new_tree',
-                                                               'type' => '82328'
+                                                               'type' => '83264'
                                                              }
                                                     },
                                          'Return' => '1',
                                          'ShortName' => 'pldm_entity_association_tree_copy_root'
                                        },
-                            '82780' => {
+                            '83716' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '640',
+                                         'Line' => '650',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'tree',
-                                                               'type' => '82328'
+                                                               'type' => '83264'
                                                              },
                                                       '1' => {
                                                                'name' => 'entity',
-                                                               'type' => '63029'
+                                                               'type' => '63965'
                                                              }
                                                     },
-                                         'Return' => '56478',
+                                         'Return' => '57414',
                                          'ShortName' => 'pldm_entity_association_tree_find'
                                        },
-                            '83060' => {
+                            '83996' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '654',
+                                         'Line' => '664',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'tree',
-                                                               'type' => '82328'
+                                                               'type' => '83264'
                                                              },
                                                       '1' => {
                                                                'name' => 'entity',
-                                                               'type' => '63029'
+                                                               'type' => '63965'
                                                              },
                                                       '2' => {
                                                                'name' => 'is_remote',
                                                                'type' => '805'
                                                              }
                                                     },
-                                         'Return' => '56478',
+                                         'Return' => '57414',
                                          'ShortName' => 'pldm_entity_association_tree_find_with_locality'
                                        },
-                            '83442' => {
+                            '84378' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '212',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '66898'
+                                                               'type' => '67834'
                                                              },
                                                       '1' => {
                                                                'name' => 'first',
@@ -4656,16 +4656,16 @@ $VAR1 = {
                                                     '1' => 'rsi',
                                                     '2' => 'rdx'
                                                   },
-                                         'Return' => '56473',
+                                         'Return' => '57409',
                                          'ShortName' => 'pldm_pdr_find_last_in_range'
                                        },
-                            '83564' => {
+                            '84500' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '168',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '63024'
+                                                               'type' => '63960'
                                                              }
                                                     },
                                          'Reg' => {
@@ -4674,13 +4674,13 @@ $VAR1 = {
                                          'Return' => '1',
                                          'ShortName' => 'pldm_pdr_remove_remote_pdrs'
                                        },
-                            '83812' => {
+                            '84748' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '177',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '63024'
+                                                               'type' => '63960'
                                                              },
                                                       '1' => {
                                                                'name' => 'terminus_handle',
@@ -4694,41 +4694,41 @@ $VAR1 = {
                                          'Return' => '1',
                                          'ShortName' => 'pldm_pdr_remove_pdrs_by_terminus_handle'
                                        },
-                            '83980' => {
+                            '84916' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '601',
+                                         'Line' => '611',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'tree',
-                                                               'type' => '82328'
+                                                               'type' => '83264'
                                                              },
                                                       '1' => {
                                                                'name' => 'entity',
-                                                               'type' => '55292'
+                                                               'type' => '55518'
                                                              },
                                                       '2' => {
                                                                'name' => 'node',
-                                                               'type' => '82775'
+                                                               'type' => '83711'
                                                              }
                                                     },
                                          'Return' => '1',
                                          'ShortName' => 'pldm_find_entity_ref_in_tree'
                                        },
-                            '84267' => {
+                            '85203' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '590',
+                                         'Line' => '600',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'node',
-                                                               'type' => '56478'
+                                                               'type' => '57414'
                                                              },
                                                       '1' => {
                                                                'name' => 'repo',
-                                                               'type' => '63024'
+                                                               'type' => '63960'
                                                              },
                                                       '2' => {
                                                                'name' => 'entities',
-                                                               'type' => '82269'
+                                                               'type' => '83205'
                                                              },
                                                       '3' => {
                                                                'name' => 'num_entities',
@@ -4759,21 +4759,21 @@ $VAR1 = {
                                          'Return' => '100',
                                          'ShortName' => 'pldm_entity_association_pdr_add_from_node_with_record_handle'
                                        },
-                            '84505' => {
+                            '85441' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '573',
+                                         'Line' => '583',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'node',
-                                                               'type' => '56478'
+                                                               'type' => '57414'
                                                              },
                                                       '1' => {
                                                                'name' => 'repo',
-                                                               'type' => '63024'
+                                                               'type' => '63960'
                                                              },
                                                       '2' => {
                                                                'name' => 'entities',
-                                                               'type' => '82269'
+                                                               'type' => '83205'
                                                              },
                                                       '3' => {
                                                                'name' => 'num_entities',
@@ -4791,17 +4791,17 @@ $VAR1 = {
                                          'Return' => '100',
                                          'ShortName' => 'pldm_entity_association_pdr_add_from_node_check'
                                        },
-                            '84723' => {
+                            '85659' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '493',
+                                         'Line' => '503',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'tree',
-                                                               'type' => '82328'
+                                                               'type' => '83264'
                                                              },
                                                       '1' => {
                                                                'name' => 'repo',
-                                                               'type' => '63024'
+                                                               'type' => '63960'
                                                              },
                                                       '2' => {
                                                                'name' => 'is_remote',
@@ -4815,17 +4815,17 @@ $VAR1 = {
                                          'Return' => '100',
                                          'ShortName' => 'pldm_entity_association_pdr_add_check'
                                        },
-                            '86271' => {
+                            '87207' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '627',
+                                         'Line' => '637',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'parent',
-                                                               'type' => '56478'
+                                                               'type' => '57414'
                                                              },
                                                       '1' => {
                                                                'name' => 'node',
-                                                               'type' => '63029'
+                                                               'type' => '63965'
                                                              }
                                                     },
                                          'Reg' => {
@@ -4835,13 +4835,13 @@ $VAR1 = {
                                          'Return' => '805',
                                          'ShortName' => 'pldm_is_current_parent_child'
                                        },
-                            '86360' => {
+                            '87296' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '613',
+                                         'Line' => '623',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'node',
-                                                               'type' => '56478'
+                                                               'type' => '57414'
                                                              },
                                                       '1' => {
                                                                'name' => 'association_type',
@@ -4855,13 +4855,13 @@ $VAR1 = {
                                          'Return' => '121',
                                          'ShortName' => 'pldm_entity_get_num_children'
                                        },
-                            '86575' => {
+                            '87511' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '464',
+                                         'Line' => '474',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'node',
-                                                               'type' => '56478'
+                                                               'type' => '57414'
                                                              }
                                                     },
                                          'Reg' => {
@@ -4870,37 +4870,37 @@ $VAR1 = {
                                          'Return' => '805',
                                          'ShortName' => 'pldm_entity_is_exist_parent'
                                        },
-                            '86730' => {
+                            '87666' => {
+                                         'Header' => 'pdr.h',
+                                         'Line' => '464',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'node',
+                                                               'type' => '57414'
+                                                             }
+                                                    },
+                                         'Return' => '55518',
+                                         'ShortName' => 'pldm_entity_get_parent'
+                                       },
+                            '87800' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '454',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'node',
-                                                               'type' => '56478'
-                                                             }
-                                                    },
-                                         'Return' => '55292',
-                                         'ShortName' => 'pldm_entity_get_parent'
-                                       },
-                            '86864' => {
-                                         'Header' => 'pdr.h',
-                                         'Line' => '444',
-                                         'Param' => {
-                                                      '0' => {
-                                                               'name' => 'node',
-                                                               'type' => '56478'
+                                                               'type' => '57414'
                                                              }
                                                     },
                                          'Return' => '805',
                                          'ShortName' => 'pldm_entity_is_node_parent'
                                        },
-                            '86998' => {
+                            '87934' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '434',
+                                         'Line' => '444',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'tree',
-                                                               'type' => '82328'
+                                                               'type' => '83264'
                                                              }
                                                     },
                                          'Reg' => {
@@ -4909,17 +4909,17 @@ $VAR1 = {
                                          'Return' => '1',
                                          'ShortName' => 'pldm_entity_association_tree_destroy'
                                        },
-                            '87081' => {
+                            '88017' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '406',
+                                         'Line' => '416',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'tree',
-                                                               'type' => '82328'
+                                                               'type' => '83264'
                                                              },
                                                       '1' => {
                                                                'name' => 'entities',
-                                                               'type' => '82269'
+                                                               'type' => '83205'
                                                              },
                                                       '2' => {
                                                                'name' => 'size',
@@ -4932,17 +4932,17 @@ $VAR1 = {
                                          'Return' => '1',
                                          'ShortName' => 'pldm_entity_association_tree_visit'
                                        },
-                            '87540' => {
+                            '88476' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '388',
+                                         'Line' => '398',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'tree',
-                                                               'type' => '82328'
+                                                               'type' => '83264'
                                                              },
                                                       '1' => {
                                                                'name' => 'entity',
-                                                               'type' => '63029'
+                                                               'type' => '63965'
                                                              },
                                                       '2' => {
                                                                'name' => 'entity_instance_number',
@@ -4950,7 +4950,7 @@ $VAR1 = {
                                                              },
                                                       '3' => {
                                                                'name' => 'parent',
-                                                               'type' => '56478'
+                                                               'type' => '57414'
                                                              },
                                                       '4' => {
                                                                'name' => 'association_type',
@@ -4971,20 +4971,20 @@ $VAR1 = {
                                                                'type' => '1011'
                                                              }
                                                     },
-                                         'Return' => '56478',
+                                         'Return' => '57414',
                                          'ShortName' => 'pldm_entity_association_tree_add_entity'
                                        },
-                            '88067' => {
+                            '89003' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '362',
+                                         'Line' => '372',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'tree',
-                                                               'type' => '82328'
+                                                               'type' => '83264'
                                                              },
                                                       '1' => {
                                                                'name' => 'entity',
-                                                               'type' => '55292'
+                                                               'type' => '55518'
                                                              }
                                                     },
                                          'Reg' => {
@@ -4993,17 +4993,17 @@ $VAR1 = {
                                          'Return' => '1',
                                          'ShortName' => 'pldm_entity_association_tree_delete_node'
                                        },
-                            '88481' => {
+                            '89417' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '351',
+                                         'Line' => '361',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'tree',
-                                                               'type' => '82328'
+                                                               'type' => '83264'
                                                              },
                                                       '1' => {
                                                                'name' => 'entity',
-                                                               'type' => '63029'
+                                                               'type' => '63965'
                                                              },
                                                       '2' => {
                                                                'name' => 'entity_instance_number',
@@ -5011,53 +5011,73 @@ $VAR1 = {
                                                              },
                                                       '3' => {
                                                                'name' => 'parent',
-                                                               'type' => '56478'
+                                                               'type' => '57414'
                                                              },
                                                       '4' => {
                                                                'name' => 'association_type',
                                                                'type' => '121'
                                                              }
                                                     },
-                                         'Return' => '56478',
+                                         'Return' => '57414',
                                          'ShortName' => 'pldm_entity_association_tree_add'
                                        },
-                            '89010' => {
+                            '89946' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '334',
-                                         'Return' => '82328',
+                                         'Line' => '344',
+                                         'Return' => '83264',
                                          'ShortName' => 'pldm_entity_association_tree_init'
                                        },
-                            '89084' => {
+                            '90020' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '428',
+                                         'Line' => '438',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'entity',
-                                                               'type' => '89218'
+                                                               'type' => '90154'
                                                              }
                                                     },
                                          'Return' => '1011',
                                          'ShortName' => 'pldm_entity_node_get_remote_container_id'
                                        },
-                            '89223' => {
+                            '90159' => {
                                          'Header' => 'pdr.h',
-                                         'Line' => '417',
+                                         'Line' => '427',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'node',
-                                                               'type' => '56478'
+                                                               'type' => '57414'
                                                              }
                                                     },
-                                         'Return' => '55292',
+                                         'Return' => '55518',
                                          'ShortName' => 'pldm_entity_extract'
                                        },
-                            '90017' => {
+                            '90953' => {
+                                         'Header' => 'pdr.h',
+                                         'Line' => '326',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'repo',
+                                                               'type' => '67834'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'record_handle',
+                                                               'type' => '1023'
+                                                             }
+                                                    },
+                                         'Reg' => {
+                                                    '0' => 'rdi',
+                                                    '1' => 'rsi'
+                                                  },
+                                         'Return' => '55518',
+                                         'ShortName' => 'pldm_get_entity_from_record_handle'
+                                       },
+                            '91367' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '199',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '63024'
+                                                               'type' => '63960'
                                                              },
                                                       '1' => {
                                                                'name' => 'record_handle',
@@ -5076,13 +5096,13 @@ $VAR1 = {
                                          'Return' => '1',
                                          'ShortName' => 'pldm_delete_by_record_handle'
                                        },
-                            '90308' => {
+                            '91658' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '190',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '66898'
+                                                               'type' => '67834'
                                                              },
                                                       '1' => {
                                                                'name' => 'terminus_handle',
@@ -5110,13 +5130,13 @@ $VAR1 = {
                                          'Return' => '1',
                                          'ShortName' => 'pldm_pdr_update_TL_pdr'
                                        },
-                            '90662' => {
+                            '92012' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '299',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '66898'
+                                                               'type' => '67834'
                                                              },
                                                       '1' => {
                                                                'name' => 'fru_rsi',
@@ -5147,16 +5167,16 @@ $VAR1 = {
                                          'Reg' => {
                                                     '2' => 'r12'
                                                   },
-                                         'Return' => '68374',
+                                         'Return' => '69310',
                                          'ShortName' => 'pldm_pdr_fru_record_find_by_rsi'
                                        },
-                            '91019' => {
+                            '92364' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '278',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '66898'
+                                                               'type' => '67834'
                                                              },
                                                       '1' => {
                                                                'name' => 'fru_rsi',
@@ -5182,16 +5202,16 @@ $VAR1 = {
                                          'Reg' => {
                                                     '2' => 'r12'
                                                   },
-                                         'Return' => '68374',
+                                         'Return' => '69310',
                                          'ShortName' => 'pldm_pdr_fru_record_set_find_by_rsi'
                                        },
-                            '91368' => {
+                            '92713' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '257',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '63024'
+                                                               'type' => '63960'
                                                              },
                                                       '1' => {
                                                                'name' => 'terminus_handle',
@@ -5222,81 +5242,81 @@ $VAR1 = {
                                          'Return' => '100',
                                          'ShortName' => 'pldm_pdr_add_fru_record_set_check'
                                        },
-                            '91707' => {
+                            '93052' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '160',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'record',
-                                                               'type' => '68374'
+                                                               'type' => '69310'
                                                              }
                                                     },
                                          'Return' => '805',
                                          'ShortName' => 'pldm_pdr_record_is_remote'
                                        },
-                            '91861' => {
+                            '93206' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '54',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '66898'
+                                                               'type' => '67834'
                                                              },
                                                       '1' => {
                                                                'name' => 'record',
-                                                               'type' => '68374'
+                                                               'type' => '69310'
                                                              }
                                                     },
                                          'Return' => '1011',
                                          'ShortName' => 'pldm_pdr_get_terminus_handle'
                                        },
-                            '92078' => {
+                            '93423' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '97',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '66898'
+                                                               'type' => '67834'
                                                              },
                                                       '1' => {
                                                                'name' => 'record',
-                                                               'type' => '68374'
+                                                               'type' => '69310'
                                                              }
                                                     },
                                          'Return' => '1023',
                                          'ShortName' => 'pldm_pdr_get_record_handle'
                                        },
-                            '92295' => {
+                            '93640' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '65',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '66898'
+                                                               'type' => '67834'
                                                              }
                                                     },
                                          'Return' => '1023',
                                          'ShortName' => 'pldm_pdr_get_repo_size'
                                        },
-                            '92426' => {
+                            '93771' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '52',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '66898'
+                                                               'type' => '67834'
                                                              }
                                                     },
                                          'Return' => '1023',
                                          'ShortName' => 'pldm_pdr_get_record_count'
                                        },
-                            '92557' => {
+                            '93902' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '150',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '66898'
+                                                               'type' => '67834'
                                                              },
                                                       '1' => {
                                                                'name' => 'pdr_type',
@@ -5304,7 +5324,7 @@ $VAR1 = {
                                                              },
                                                       '2' => {
                                                                'name' => 'curr_record',
-                                                               'type' => '68374'
+                                                               'type' => '69310'
                                                              },
                                                       '3' => {
                                                                'name' => 'data',
@@ -5320,20 +5340,20 @@ $VAR1 = {
                                                     '3' => 'rcx',
                                                     '4' => 'r8'
                                                   },
-                                         'Return' => '68374',
+                                         'Return' => '69310',
                                          'ShortName' => 'pldm_pdr_find_record_by_type'
                                        },
-                            '92728' => {
+                            '94073' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '132',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '66898'
+                                                               'type' => '67834'
                                                              },
                                                       '1' => {
                                                                'name' => 'curr_record',
-                                                               'type' => '68374'
+                                                               'type' => '69310'
                                                              },
                                                       '2' => {
                                                                'name' => 'data',
@@ -5355,16 +5375,16 @@ $VAR1 = {
                                                     '3' => 'rcx',
                                                     '4' => 'rbp'
                                                   },
-                                         'Return' => '68374',
+                                         'Return' => '69310',
                                          'ShortName' => 'pldm_pdr_get_next_record'
                                        },
-                            '92895' => {
+                            '94240' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '113',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '66898'
+                                                               'type' => '67834'
                                                              },
                                                       '1' => {
                                                                'name' => 'record_handle',
@@ -5390,16 +5410,16 @@ $VAR1 = {
                                                     '3' => 'rcx',
                                                     '4' => 'rbp'
                                                   },
-                                         'Return' => '68374',
+                                         'Return' => '69310',
                                          'ShortName' => 'pldm_pdr_find_record'
                                        },
-                            '93063' => {
+                            '94408' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '42',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '63024'
+                                                               'type' => '63960'
                                                              }
                                                     },
                                          'Reg' => {
@@ -5408,19 +5428,19 @@ $VAR1 = {
                                          'Return' => '1',
                                          'ShortName' => 'pldm_pdr_destroy'
                                        },
-                            '93216' => {
+                            '94561' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '36',
-                                         'Return' => '63024',
+                                         'Return' => '63960',
                                          'ShortName' => 'pldm_pdr_init'
                                        },
-                            '93288' => {
+                            '94633' => {
                                          'Header' => 'pdr.h',
                                          'Line' => '82',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'repo',
-                                                               'type' => '63024'
+                                                               'type' => '63960'
                                                              },
                                                       '1' => {
                                                                'name' => 'data',
@@ -5452,7 +5472,7 @@ $VAR1 = {
                                          'Return' => '100',
                                          'ShortName' => 'pldm_pdr_add_check'
                                        },
-                            '100772' => {
+                            '102117' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1714',
                                           'Param' => {
@@ -5462,7 +5482,7 @@ $VAR1 = {
                                                               },
                                                        '1' => {
                                                                 'name' => 'resp',
-                                                                'type' => '102373'
+                                                                'type' => '103718'
                                                               },
                                                        '2' => {
                                                                 'name' => 'msg',
@@ -5479,7 +5499,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_get_state_effecter_states_resp'
                                         },
-                            '102393' => {
+                            '103738' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1697',
                                           'Param' => {
@@ -5493,13 +5513,13 @@ $VAR1 = {
                                                               },
                                                        '2' => {
                                                                 'name' => 'resp',
-                                                                'type' => '102373'
+                                                                'type' => '103718'
                                                               }
                                                      },
                                           'Return' => '100',
                                           'ShortName' => 'decode_get_state_effecter_states_resp'
                                         },
-                            '103914' => {
+                            '105259' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1666',
                                           'Param' => {
@@ -5519,7 +5539,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_get_state_effecter_states_req'
                                         },
-                            '104685' => {
+                            '106030' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1680',
                                           'Param' => {
@@ -5543,7 +5563,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_get_state_effecter_states_req'
                                         },
-                            '146017' => {
+                            '147362' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1846',
                                           'Param' => {
@@ -5600,7 +5620,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_poll_for_platform_event_message_resp'
                                         },
-                            '148726' => {
+                            '150071' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1820',
                                           'Param' => {
@@ -5637,7 +5657,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_poll_for_platform_event_message_req'
                                         },
-                            '150143' => {
+                            '151488' => {
                                           'Header' => 'platform.h',
                                           'Line' => '2299',
                                           'Param' => {
@@ -5657,7 +5677,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_set_event_receiver_resp'
                                         },
-                            '150314' => {
+                            '151659' => {
                                           'Header' => 'platform.h',
                                           'Line' => '2285',
                                           'Param' => {
@@ -5689,7 +5709,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_set_event_receiver_req'
                                         },
-                            '151737' => {
+                            '153082' => {
                                           'Header' => 'platform.h',
                                           'Line' => '2263',
                                           'Param' => {
@@ -5714,7 +5734,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_set_event_receiver_resp'
                                         },
-                            '152399' => {
+                            '153744' => {
                                           'Header' => 'platform.h',
                                           'Line' => '2249',
                                           'Param' => {
@@ -5746,7 +5766,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_set_event_receiver_req'
                                         },
-                            '152655' => {
+                            '154000' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1393',
                                           'Param' => {
@@ -5770,7 +5790,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_get_sensor_reading_req'
                                         },
-                            '153640' => {
+                            '154985' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1419',
                                           'Param' => {
@@ -5827,7 +5847,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_get_sensor_reading_resp'
                                         },
-                            '154190' => {
+                            '155535' => {
                                           'Header' => 'platform.h',
                                           'Line' => '2224',
                                           'Param' => {
@@ -5879,7 +5899,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_get_sensor_reading_resp'
                                         },
-                            '157788' => {
+                            '159133' => {
                                           'Header' => 'platform.h',
                                           'Line' => '2199',
                                           'Param' => {
@@ -5903,7 +5923,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_get_sensor_reading_req'
                                         },
-                            '158004' => {
+                            '159349' => {
                                           'Header' => 'platform.h',
                                           'Line' => '2180',
                                           'Param' => {
@@ -5937,7 +5957,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_pldm_pdr_repository_change_record_data'
                                         },
-                            '161301' => {
+                            '162646' => {
                                           'Header' => 'platform.h',
                                           'Line' => '2063',
                                           'Param' => {
@@ -5971,7 +5991,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_pldm_pdr_repository_chg_event_data'
                                         },
-                            '162183' => {
+                            '163528' => {
                                           'Header' => 'platform.h',
                                           'Line' => '2134',
                                           'Param' => {
@@ -5993,11 +6013,11 @@ $VAR1 = {
                                                               },
                                                        '4' => {
                                                                 'name' => 'change_entries',
-                                                                'type' => '162501'
+                                                                'type' => '163846'
                                                               },
                                                        '5' => {
                                                                 'name' => 'event_data',
-                                                                'type' => '162516'
+                                                                'type' => '163861'
                                                               },
                                                        '6' => {
                                                                 'name' => 'actual_change_records_size',
@@ -6021,7 +6041,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_pldm_pdr_repository_chg_event_data'
                                         },
-                            '162526' => {
+                            '163871' => {
                                           'Header' => 'platform.h',
                                           'Line' => '2041',
                                           'Param' => {
@@ -6058,7 +6078,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_get_numeric_effecter_value_resp'
                                         },
-                            '166880' => {
+                            '168225' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1350',
                                           'Param' => {
@@ -6078,7 +6098,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_get_numeric_effecter_value_req'
                                         },
-                            '167646' => {
+                            '168991' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1374',
                                           'Param' => {
@@ -6120,7 +6140,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_get_numeric_effecter_value_resp'
                                         },
-                            '168336' => {
+                            '169681' => {
                                           'Header' => 'platform.h',
                                           'Line' => '2020',
                                           'Param' => {
@@ -6140,7 +6160,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_get_numeric_effecter_value_req'
                                         },
-                            '168532' => {
+                            '169877' => {
                                           'Header' => 'platform.h',
                                           'Line' => '2005',
                                           'Param' => {
@@ -6154,13 +6174,13 @@ $VAR1 = {
                                                               },
                                                        '2' => {
                                                                 'name' => 'pdr_value',
-                                                                'type' => '227018'
+                                                                'type' => '228363'
                                                               }
                                                      },
                                           'Return' => '100',
                                           'ShortName' => 'decode_numeric_sensor_pdr_data'
                                         },
-                            '227023' => {
+                            '228368' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1993',
                                           'Param' => {
@@ -6196,7 +6216,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_numeric_sensor_data'
                                         },
-                            '229665' => {
+                            '231010' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1972',
                                           'Param' => {
@@ -6230,7 +6250,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_state_sensor_data'
                                         },
-                            '230746' => {
+                            '232091' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1954',
                                           'Param' => {
@@ -6259,7 +6279,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_sensor_op_data'
                                         },
-                            '231608' => {
+                            '232953' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1937',
                                           'Param' => {
@@ -6287,7 +6307,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_sensor_event_data'
                                         },
-                            '232540' => {
+                            '233885' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1916',
                                           'Param' => {
@@ -6334,7 +6354,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_event_message_supported_resp'
                                         },
-                            '234177' => {
+                            '235522' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1899',
                                           'Param' => {
@@ -6354,7 +6374,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_event_message_supported_req'
                                         },
-                            '234373' => {
+                            '235718' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1872',
                                           'Param' => {
@@ -6378,7 +6398,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_event_message_buffer_size_resp'
                                         },
-                            '235358' => {
+                            '236703' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1885',
                                           'Param' => {
@@ -6401,7 +6421,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_event_message_buffer_size_req'
                                         },
-                            '235554' => {
+                            '236899' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1861',
                                           'Param' => {
@@ -6428,7 +6448,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_platform_event_message_resp'
                                         },
-                            '236360' => {
+                            '237705' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1804',
                                           'Param' => {
@@ -6470,7 +6490,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_platform_event_message_req'
                                         },
-                            '236759' => {
+                            '238104' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1784',
                                           'Param' => {
@@ -6532,7 +6552,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_poll_for_platform_event_message_resp'
                                         },
-                            '239455' => {
+                            '240800' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1762',
                                           'Param' => {
@@ -6556,7 +6576,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_platform_event_message_resp'
                                         },
-                            '239671' => {
+                            '241016' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1747',
                                           'Param' => {
@@ -6588,7 +6608,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_poll_for_platform_event_message_req'
                                         },
-                            '241107' => {
+                            '242452' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1731',
                                           'Param' => {
@@ -6627,13 +6647,13 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_platform_event_message_req'
                                         },
-                            '242227' => {
+                            '243572' => {
                                           'Header' => 'platform.h',
                                           'Line' => '2158',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'event_data',
-                                                                'type' => '242417'
+                                                                'type' => '243762'
                                                               },
                                                        '1' => {
                                                                 'name' => 'event_data_size',
@@ -6645,7 +6665,7 @@ $VAR1 = {
                                                               },
                                                        '3' => {
                                                                 'name' => 'sensor_event_class',
-                                                                'type' => '96981'
+                                                                'type' => '98326'
                                                               },
                                                        '4' => {
                                                                 'name' => 'sensor_offset',
@@ -6662,7 +6682,7 @@ $VAR1 = {
                                                               },
                                                        '7' => {
                                                                 'name' => 'actual_event_data_size',
-                                                                'type' => '158891'
+                                                                'type' => '160236'
                                                               }
                                                      },
                                           'Reg' => {
@@ -6676,7 +6696,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_sensor_event_data'
                                         },
-                            '242432' => {
+                            '243777' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1315',
                                           'Param' => {
@@ -6704,7 +6724,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_get_state_sensor_readings_req'
                                         },
-                            '243636' => {
+                            '244981' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1651',
                                           'Param' => {
@@ -6726,7 +6746,7 @@ $VAR1 = {
                                                               },
                                                        '4' => {
                                                                 'name' => 'field',
-                                                                'type' => '245351'
+                                                                'type' => '246696'
                                                               }
                                                      },
                                           'Reg' => {
@@ -6737,7 +6757,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_get_state_sensor_readings_resp'
                                         },
-                            '245356' => {
+                            '246701' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1631',
                                           'Param' => {
@@ -6765,7 +6785,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_get_state_sensor_readings_req'
                                         },
-                            '245592' => {
+                            '246937' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1335',
                                           'Param' => {
@@ -6783,7 +6803,7 @@ $VAR1 = {
                                                               },
                                                        '3' => {
                                                                 'name' => 'field',
-                                                                'type' => '245351'
+                                                                'type' => '246696'
                                                               },
                                                        '4' => {
                                                                 'name' => 'msg',
@@ -6793,7 +6813,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_get_state_sensor_readings_resp'
                                         },
-                            '245944' => {
+                            '247289' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1612',
                                           'Param' => {
@@ -6818,7 +6838,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_set_numeric_effecter_value_resp'
                                         },
-                            '246020' => {
+                            '247365' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1599',
                                           'Param' => {
@@ -6853,7 +6873,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_set_numeric_effecter_value_req'
                                         },
-                            '246488' => {
+                            '247833' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1206',
                                           'Param' => {
@@ -6877,7 +6897,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_set_numeric_effecter_value_resp'
                                         },
-                            '246679' => {
+                            '248024' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1190',
                                           'Param' => {
@@ -6905,7 +6925,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_set_numeric_effecter_value_req'
                                         },
-                            '249285' => {
+                            '250630' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1530',
                                           'Param' => {
@@ -6960,7 +6980,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_get_pdr_resp'
                                         },
-                            '251595' => {
+                            '252940' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1499',
                                           'Param' => {
@@ -7005,7 +7025,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_get_pdr_req'
                                         },
-                            '251883' => {
+                            '253228' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1473',
                                           'Param' => {
@@ -7057,7 +7077,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_get_pdr_repository_info_resp'
                                         },
-                            '254365' => {
+                            '255710' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1449',
                                           'Param' => {
@@ -7109,7 +7129,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_get_pdr_repository_info_resp'
                                         },
-                            '254841' => {
+                            '256186' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1273',
                                           'Param' => {
@@ -7156,7 +7176,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_get_pdr_resp'
                                         },
-                            '255293' => {
+                            '256638' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1294',
                                           'Param' => {
@@ -7193,7 +7213,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_get_pdr_req'
                                         },
-                            '257191' => {
+                            '258536' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1245',
                                           'Param' => {
@@ -7215,13 +7235,13 @@ $VAR1 = {
                                                               },
                                                        '4' => {
                                                                 'name' => 'field',
-                                                                'type' => '258611'
+                                                                'type' => '259956'
                                                               }
                                                      },
                                           'Return' => '100',
                                           'ShortName' => 'decode_set_state_effecter_states_req'
                                         },
-                            '258616' => {
+                            '259961' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1578',
                                           'Param' => {
@@ -7246,7 +7266,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_set_state_effecter_states_resp'
                                         },
-                            '258689' => {
+                            '260034' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1559',
                                           'Param' => {
@@ -7264,7 +7284,7 @@ $VAR1 = {
                                                               },
                                                        '3' => {
                                                                 'name' => 'field',
-                                                                'type' => '258611'
+                                                                'type' => '259956'
                                                               },
                                                        '4' => {
                                                                 'name' => 'msg',
@@ -7277,7 +7297,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_set_state_effecter_states_req'
                                         },
-                            '259032' => {
+                            '260377' => {
                                           'Header' => 'platform.h',
                                           'Line' => '1223',
                                           'Param' => {
@@ -7297,13 +7317,13 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_set_state_effecter_states_resp'
                                         },
-                            '259198' => {
+                            '260543' => {
                                           'Header' => 'platform.h',
                                           'Line' => '640',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'sensor',
-                                                                'type' => '259582'
+                                                                'type' => '260927'
                                                               },
                                                        '1' => {
                                                                 'name' => 'allocation_size',
@@ -7311,7 +7331,7 @@ $VAR1 = {
                                                               },
                                                        '2' => {
                                                                 'name' => 'possible_states',
-                                                                'type' => '259592'
+                                                                'type' => '260937'
                                                               },
                                                        '3' => {
                                                                 'name' => 'possible_states_size',
@@ -7319,7 +7339,7 @@ $VAR1 = {
                                                               },
                                                        '4' => {
                                                                 'name' => 'actual_size',
-                                                                'type' => '158891'
+                                                                'type' => '160236'
                                                               }
                                                      },
                                           'Reg' => {
@@ -7332,13 +7352,13 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_state_sensor_pdr'
                                         },
-                            '259602' => {
+                            '260947' => {
                                           'Header' => 'platform.h',
                                           'Line' => '842',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'effecter',
-                                                                'type' => '259986'
+                                                                'type' => '261331'
                                                               },
                                                        '1' => {
                                                                 'name' => 'allocation_size',
@@ -7346,7 +7366,7 @@ $VAR1 = {
                                                               },
                                                        '2' => {
                                                                 'name' => 'possible_states',
-                                                                'type' => '259996'
+                                                                'type' => '261341'
                                                               },
                                                        '3' => {
                                                                 'name' => 'possible_states_size',
@@ -7354,7 +7374,7 @@ $VAR1 = {
                                                               },
                                                        '4' => {
                                                                 'name' => 'actual_size',
-                                                                'type' => '158891'
+                                                                'type' => '160236'
                                                               }
                                                      },
                                           'Reg' => {
@@ -7367,13 +7387,13 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_state_effecter_pdr'
                                         },
-                            '266004' => {
+                            '267349' => {
                                           'Header' => 'instance-id.h',
                                           'Line' => '85',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'ctx',
-                                                                'type' => '266227'
+                                                                'type' => '267572'
                                                               },
                                                        '1' => {
                                                                 'name' => 'tid',
@@ -7387,13 +7407,13 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'pldm_instance_id_free'
                                         },
-                            '266232' => {
+                            '267577' => {
                                           'Header' => 'instance-id.h',
                                           'Line' => '68',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'ctx',
-                                                                'type' => '266227'
+                                                                'type' => '267572'
                                                               },
                                                        '1' => {
                                                                 'name' => 'tid',
@@ -7401,19 +7421,19 @@ $VAR1 = {
                                                               },
                                                        '2' => {
                                                                 'name' => 'iid',
-                                                                'type' => '266652'
+                                                                'type' => '267997'
                                                               }
                                                      },
                                           'Return' => '100',
                                           'ShortName' => 'pldm_instance_id_alloc'
                                         },
-                            '266657' => {
+                            '268002' => {
                                           'Header' => 'instance-id.h',
                                           'Line' => '51',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'ctx',
-                                                                'type' => '266227'
+                                                                'type' => '267572'
                                                               }
                                                      },
                                           'Reg' => {
@@ -7422,25 +7442,25 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'pldm_instance_db_destroy'
                                         },
-                            '266742' => {
+                            '268087' => {
                                           'Header' => 'instance-id.h',
                                           'Line' => '41',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'ctx',
-                                                                'type' => '266828'
+                                                                'type' => '268173'
                                                               }
                                                      },
                                           'Return' => '100',
                                           'ShortName' => 'pldm_instance_db_init_default'
                                         },
-                            '266833' => {
+                            '268178' => {
                                           'Header' => 'instance-id.h',
                                           'Line' => '28',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'ctx',
-                                                                'type' => '266828'
+                                                                'type' => '268173'
                                                               },
                                                        '1' => {
                                                                 'name' => 'dbpath',
@@ -7450,13 +7470,13 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'pldm_instance_db_init'
                                         },
-                            '267749' => {
+                            '269094' => {
                                           'Header' => 'transport.h',
                                           'Line' => '53',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'transport',
-                                                                'type' => '267786'
+                                                                'type' => '269131'
                                                               },
                                                        '1' => {
                                                                 'name' => 'tid',
@@ -7477,16 +7497,16 @@ $VAR1 = {
                                                      '2' => 'rdx',
                                                      '3' => 'rcx'
                                                    },
-                                          'Return' => '267700',
+                                          'Return' => '269045',
                                           'ShortName' => 'pldm_transport_send_msg'
                                         },
-                            '267796' => {
+                            '269141' => {
                                           'Header' => 'transport.h',
                                           'Line' => '118',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'transport',
-                                                                'type' => '267786'
+                                                                'type' => '269131'
                                                               },
                                                        '1' => {
                                                                 'name' => 'tid',
@@ -7512,16 +7532,16 @@ $VAR1 = {
                                           'Reg' => {
                                                      '2' => 'r14'
                                                    },
-                                          'Return' => '267700',
+                                          'Return' => '269045',
                                           'ShortName' => 'pldm_transport_send_recv_msg'
                                         },
-                            '267853' => {
+                            '269198' => {
                                           'Header' => 'mctp-demux.h',
                                           'Line' => '18',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'ctx',
-                                                                'type' => '267744'
+                                                                'type' => '269089'
                                                               }
                                                      },
                                           'Reg' => {
@@ -7530,17 +7550,17 @@ $VAR1 = {
                                           'Return' => '1',
                                           'ShortName' => 'pldm_transport_mctp_demux_destroy'
                                         },
-                            '267890' => {
+                            '269235' => {
                                           'Header' => 'transport.h',
                                           'Line' => '81',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'transport',
-                                                                'type' => '267786'
+                                                                'type' => '269131'
                                                               },
                                                        '1' => {
                                                                 'name' => 'tid',
-                                                                'type' => '267927'
+                                                                'type' => '269272'
                                                               },
                                                        '2' => {
                                                                 'name' => 'pldm_msg',
@@ -7557,16 +7577,16 @@ $VAR1 = {
                                                      '2' => 'rbp',
                                                      '3' => 'rcx'
                                                    },
-                                          'Return' => '267700',
+                                          'Return' => '269045',
                                           'ShortName' => 'pldm_transport_recv_msg'
                                         },
-                            '267932' => {
+                            '269277' => {
                                           'Header' => 'mctp-demux.h',
                                           'Line' => '32',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'ctx',
-                                                                'type' => '267744'
+                                                                'type' => '269089'
                                                               },
                                                        '1' => {
                                                                 'name' => 'tid',
@@ -7574,7 +7594,7 @@ $VAR1 = {
                                                               },
                                                        '2' => {
                                                                 'name' => 'eid',
-                                                                'type' => '267585'
+                                                                'type' => '268930'
                                                               }
                                                      },
                                           'Reg' => {
@@ -7585,28 +7605,28 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'pldm_transport_mctp_demux_map_tid'
                                         },
-                            '267964' => {
+                            '269309' => {
                                           'Header' => 'mctp-demux.h',
                                           'Line' => '22',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'ctx',
-                                                                'type' => '267744'
+                                                                'type' => '269089'
                                                               }
                                                      },
                                           'Reg' => {
                                                      '0' => 'rdi'
                                                    },
-                                          'Return' => '267786',
+                                          'Return' => '269131',
                                           'ShortName' => 'pldm_transport_mctp_demux_core'
                                         },
-                            '268008' => {
+                            '269353' => {
                                           'Header' => 'mctp-demux.h',
                                           'Line' => '15',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'ctx',
-                                                                'type' => '268030'
+                                                                'type' => '269375'
                                                               }
                                                      },
                                           'Reg' => {
@@ -7615,19 +7635,19 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'pldm_transport_mctp_demux_init'
                                         },
-                            '268089' => {
+                            '269434' => {
                                           'Header' => 'pldm.h',
                                           'Line' => '119',
                                           'Return' => '1',
                                           'ShortName' => 'pldm_close'
                                         },
-                            '268133' => {
+                            '269478' => {
                                           'Header' => 'pldm.h',
                                           'Line' => '75',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'eid',
-                                                                'type' => '267585'
+                                                                'type' => '268930'
                                                               },
                                                        '1' => {
                                                                 'name' => 'mctp_fd',
@@ -7648,16 +7668,16 @@ $VAR1 = {
                                                      '2' => 'rdx',
                                                      '3' => 'rcx'
                                                    },
-                                          'Return' => '267700',
+                                          'Return' => '269045',
                                           'ShortName' => 'pldm_send'
                                         },
-                            '268552' => {
+                            '269897' => {
                                           'Header' => 'pldm.h',
                                           'Line' => '57',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'eid',
-                                                                'type' => '267585'
+                                                                'type' => '268930'
                                                               },
                                                        '1' => {
                                                                 'name' => 'mctp_fd',
@@ -7688,16 +7708,16 @@ $VAR1 = {
                                                      '4' => 'r8',
                                                      '5' => 'r9'
                                                    },
-                                          'Return' => '267700',
+                                          'Return' => '269045',
                                           'ShortName' => 'pldm_send_recv'
                                         },
-                            '269035' => {
+                            '270380' => {
                                           'Header' => 'pldm.h',
                                           'Line' => '94',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'eid',
-                                                                'type' => '267585'
+                                                                'type' => '268930'
                                                               },
                                                        '1' => {
                                                                 'name' => 'mctp_fd',
@@ -7719,16 +7739,16 @@ $VAR1 = {
                                           'Reg' => {
                                                      '3' => 'rbx'
                                                    },
-                                          'Return' => '267700',
+                                          'Return' => '269045',
                                           'ShortName' => 'pldm_recv'
                                         },
-                            '269261' => {
+                            '270606' => {
                                           'Header' => 'pldm.h',
                                           'Line' => '112',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'eid',
-                                                                'type' => '267585'
+                                                                'type' => '268930'
                                                               },
                                                        '1' => {
                                                                 'name' => 'mctp_fd',
@@ -7747,26 +7767,26 @@ $VAR1 = {
                                                      '2' => 'r12',
                                                      '3' => 'r13'
                                                    },
-                                          'Return' => '267700',
+                                          'Return' => '269045',
                                           'ShortName' => 'pldm_recv_any'
                                         },
-                            '269714' => {
+                            '271059' => {
                                           'Header' => 'pldm.h',
                                           'Line' => '39',
-                                          'Return' => '267700',
+                                          'Return' => '269045',
                                           'ShortName' => 'pldm_open'
                                         },
-                            '272083' => {
+                            '273428' => {
                                           'Header' => 'af-mctp.h',
                                           'Line' => '54',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'transport',
-                                                                'type' => '272239'
+                                                                'type' => '273584'
                                                               },
                                                        '1' => {
                                                                 'name' => 'smctp',
-                                                                'type' => '272244'
+                                                                'type' => '273589'
                                                               },
                                                        '2' => {
                                                                 'name' => 'len',
@@ -7780,13 +7800,13 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'pldm_transport_af_mctp_bind'
                                         },
-                            '272249' => {
+                            '273594' => {
                                           'Header' => 'af-mctp.h',
                                           'Line' => '19',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'ctx',
-                                                                'type' => '272239'
+                                                                'type' => '273584'
                                                               }
                                                      },
                                           'Reg' => {
@@ -7795,13 +7815,13 @@ $VAR1 = {
                                           'Return' => '1',
                                           'ShortName' => 'pldm_transport_af_mctp_destroy'
                                         },
-                            '272333' => {
+                            '273678' => {
                                           'Header' => 'af-mctp.h',
                                           'Line' => '16',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'ctx',
-                                                                'type' => '272557'
+                                                                'type' => '273902'
                                                               }
                                                      },
                                           'Reg' => {
@@ -7810,13 +7830,13 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'pldm_transport_af_mctp_init'
                                         },
-                            '273752' => {
+                            '275097' => {
                                           'Header' => 'af-mctp.h',
                                           'Line' => '37',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'ctx',
-                                                                'type' => '272239'
+                                                                'type' => '273584'
                                                               },
                                                        '1' => {
                                                                 'name' => 'tid',
@@ -7824,7 +7844,7 @@ $VAR1 = {
                                                               },
                                                        '2' => {
                                                                 'name' => 'eid',
-                                                                'type' => '267585'
+                                                                'type' => '268930'
                                                               }
                                                      },
                                           'Reg' => {
@@ -7835,13 +7855,13 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'pldm_transport_af_mctp_unmap_tid'
                                         },
-                            '273825' => {
+                            '275170' => {
                                           'Header' => 'af-mctp.h',
                                           'Line' => '33',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'ctx',
-                                                                'type' => '272239'
+                                                                'type' => '273584'
                                                               },
                                                        '1' => {
                                                                 'name' => 'tid',
@@ -7849,7 +7869,7 @@ $VAR1 = {
                                                               },
                                                        '2' => {
                                                                 'name' => 'eid',
-                                                                'type' => '267585'
+                                                                'type' => '268930'
                                                               }
                                                      },
                                           'Reg' => {
@@ -7860,17 +7880,17 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'pldm_transport_af_mctp_map_tid'
                                         },
-                            '274066' => {
+                            '275411' => {
                                           'Header' => 'af-mctp.h',
                                           'Line' => '28',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 't',
-                                                                'type' => '267786'
+                                                                'type' => '269131'
                                                               },
                                                        '1' => {
                                                                 'name' => 'pollfd',
-                                                                'type' => '270749'
+                                                                'type' => '272094'
                                                               }
                                                      },
                                           'Reg' => {
@@ -7880,28 +7900,28 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'pldm_transport_af_mctp_init_pollfd'
                                         },
-                            '274144' => {
+                            '275489' => {
                                           'Header' => 'af-mctp.h',
                                           'Line' => '23',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'ctx',
-                                                                'type' => '272239'
+                                                                'type' => '273584'
                                                               }
                                                      },
                                           'Reg' => {
                                                      '0' => 'rdi'
                                                    },
-                                          'Return' => '267786',
+                                          'Return' => '269131',
                                           'ShortName' => 'pldm_transport_af_mctp_core'
                                         },
-                            '277815' => {
+                            '279160' => {
                                           'Header' => 'mctp-demux.h',
                                           'Line' => '36',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'ctx',
-                                                                'type' => '267744'
+                                                                'type' => '269089'
                                                               },
                                                        '1' => {
                                                                 'name' => 'tid',
@@ -7909,7 +7929,7 @@ $VAR1 = {
                                                               },
                                                        '2' => {
                                                                 'name' => 'eid',
-                                                                'type' => '267585'
+                                                                'type' => '268930'
                                                               }
                                                      },
                                           'Reg' => {
@@ -7920,17 +7940,17 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'pldm_transport_mctp_demux_unmap_tid'
                                         },
-                            '278129' => {
+                            '279474' => {
                                           'Header' => 'mctp-demux.h',
                                           'Line' => '27',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 't',
-                                                                'type' => '267786'
+                                                                'type' => '269131'
                                                               },
                                                        '1' => {
                                                                 'name' => 'pollfd',
-                                                                'type' => '270749'
+                                                                'type' => '272094'
                                                               }
                                                      },
                                           'Reg' => {
@@ -7940,13 +7960,13 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'pldm_transport_mctp_demux_init_pollfd'
                                         },
-                            '283062' => {
+                            '284407' => {
                                           'Header' => 'transport.h',
                                           'Line' => '31',
                                           'Param' => {
                                                        '0' => {
                                                                 'name' => 'transport',
-                                                                'type' => '267786'
+                                                                'type' => '269131'
                                                               },
                                                        '1' => {
                                                                 'name' => 'timeout',
@@ -7956,7 +7976,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'pldm_transport_poll'
                                         },
-                            '288121' => {
+                            '289466' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '912',
                                           'Param' => {
@@ -7976,7 +7996,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_new_file_with_metadata_resp'
                                         },
-                            '288321' => {
+                            '289666' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '898',
                                           'Param' => {
@@ -8030,7 +8050,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_new_file_with_metadata_req'
                                         },
-                            '288553' => {
+                            '289898' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '881',
                                           'Param' => {
@@ -8055,7 +8075,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_new_file_with_metadata_resp'
                                         },
-                            '288654' => {
+                            '289999' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '866',
                                           'Param' => {
@@ -8105,7 +8125,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_new_file_with_metadata_req'
                                         },
-                            '288951' => {
+                            '290296' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '824',
                                           'Param' => {
@@ -8125,7 +8145,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_file_ack_with_meta_data_resp'
                                         },
-                            '289146' => {
+                            '290491' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '811',
                                           'Param' => {
@@ -8179,7 +8199,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_file_ack_with_meta_data_req'
                                         },
-                            '289358' => {
+                            '290703' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '794',
                                           'Param' => {
@@ -8204,7 +8224,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_file_ack_with_meta_data_resp'
                                         },
-                            '289454' => {
+                            '290799' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '781',
                                           'Param' => {
@@ -8254,7 +8274,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_file_ack_with_meta_data_req'
                                         },
-                            '289751' => {
+                            '291096' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '741',
                                           'Param' => {
@@ -8279,7 +8299,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_file_ack_resp'
                                         },
-                            '289852' => {
+                            '291197' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '730',
                                           'Param' => {
@@ -8307,7 +8327,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_file_ack_req'
                                         },
-                            '290087' => {
+                            '291432' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '718',
                                           'Param' => {
@@ -8327,7 +8347,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_file_ack_resp'
                                         },
-                            '290277' => {
+                            '291622' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '706',
                                           'Param' => {
@@ -8361,7 +8381,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_file_ack_req'
                                         },
-                            '290419' => {
+                            '291764' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '675',
                                           'Param' => {
@@ -8391,7 +8411,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_rw_file_by_type_resp'
                                         },
-                            '290534' => {
+                            '291879' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '661',
                                           'Param' => {
@@ -8428,7 +8448,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_rw_file_by_type_req'
                                         },
-                            '290804' => {
+                            '292149' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '644',
                                           'Param' => {
@@ -8456,7 +8476,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_rw_file_by_type_resp'
                                         },
-                            '291034' => {
+                            '292379' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '626',
                                           'Param' => {
@@ -8495,7 +8515,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_rw_file_by_type_req'
                                         },
-                            '291196' => {
+                            '292541' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '590',
                                           'Param' => {
@@ -8520,7 +8540,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_new_file_resp'
                                         },
-                            '291297' => {
+                            '292642' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '579',
                                           'Param' => {
@@ -8548,7 +8568,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_new_file_req'
                                         },
-                            '291532' => {
+                            '292877' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '567',
                                           'Param' => {
@@ -8568,7 +8588,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_new_file_resp'
                                         },
-                            '291722' => {
+                            '293067' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '555',
                                           'Param' => {
@@ -8602,7 +8622,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_new_file_req'
                                         },
-                            '291864' => {
+                            '293209' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '523',
                                           'Param' => {
@@ -8632,7 +8652,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_rw_file_by_type_memory_resp'
                                         },
-                            '291979' => {
+                            '293324' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '509',
                                           'Param' => {
@@ -8674,7 +8694,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_rw_file_by_type_memory_req'
                                         },
-                            '292264' => {
+                            '293609' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '491',
                                           'Param' => {
@@ -8702,7 +8722,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_rw_file_by_type_memory_resp'
                                         },
-                            '292494' => {
+                            '293839' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '473',
                                           'Param' => {
@@ -8746,7 +8766,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_rw_file_by_type_memory_req'
                                         },
-                            '292671' => {
+                            '294016' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '435',
                                           'Param' => {
@@ -8770,7 +8790,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_write_file_resp'
                                         },
-                            '292886' => {
+                            '294231' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '422',
                                           'Param' => {
@@ -8800,7 +8820,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_write_file_resp'
                                         },
-                            '292996' => {
+                            '294341' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '410',
                                           'Param' => {
@@ -8828,7 +8848,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_write_file_req'
                                         },
-                            '293231' => {
+                            '294576' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '391',
                                           'Param' => {
@@ -8866,7 +8886,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_write_file_req'
                                         },
-                            '293386' => {
+                            '294731' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '377',
                                           'Param' => {
@@ -8890,7 +8910,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_read_file_resp'
                                         },
-                            '293601' => {
+                            '294946' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '359',
                                           'Param' => {
@@ -8924,7 +8944,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_read_file_resp'
                                         },
-                            '293737' => {
+                            '295082' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '344',
                                           'Param' => {
@@ -8952,7 +8972,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_read_file_req'
                                         },
-                            '293972' => {
+                            '295317' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '330',
                                           'Param' => {
@@ -8986,7 +9006,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_read_file_req'
                                         },
-                            '294108' => {
+                            '295453' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '274',
                                           'Param' => {
@@ -9030,7 +9050,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_get_file_table_resp'
                                         },
-                            '294282' => {
+                            '295627' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '258',
                                           'Param' => {
@@ -9058,7 +9078,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_get_file_table_req'
                                         },
-                            '294509' => {
+                            '295854' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '244',
                                           'Param' => {
@@ -9098,7 +9118,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_get_file_table_resp'
                                         },
-                            '294867' => {
+                            '296212' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '227',
                                           'Param' => {
@@ -9132,7 +9152,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_get_file_table_req'
                                         },
-                            '295002' => {
+                            '296347' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '183',
                                           'Param' => {
@@ -9162,7 +9182,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_rw_file_memory_resp'
                                         },
-                            '295111' => {
+                            '296456' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '169',
                                           'Param' => {
@@ -9202,7 +9222,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_rw_file_memory_req'
                                         },
-                            '295370' => {
+                            '296715' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '152',
                                           'Param' => {
@@ -9230,7 +9250,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_rw_file_memory_resp'
                                         },
-                            '295591' => {
+                            '296936' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '136',
                                           'Param' => {
@@ -9269,7 +9289,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_rw_file_memory_req'
                                         },
-                            '296640' => {
+                            '297985' => {
                                           'Header' => 'host.h',
                                           'Line' => '101',
                                           'Param' => {
@@ -9304,7 +9324,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_get_alert_status_resp'
                                         },
-                            '296888' => {
+                            '298233' => {
                                           'Header' => 'host.h',
                                           'Line' => '86',
                                           'Param' => {
@@ -9329,7 +9349,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_get_alert_status_req'
                                         },
-                            '296971' => {
+                            '298316' => {
                                           'Header' => 'host.h',
                                           'Line' => '70',
                                           'Param' => {
@@ -9363,7 +9383,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'decode_get_alert_status_resp'
                                         },
-                            '297110' => {
+                            '298455' => {
                                           'Header' => 'host.h',
                                           'Line' => '52',
                                           'Param' => {
@@ -9387,7 +9407,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_get_alert_status_req'
                                         },
-                            '298178' => {
+                            '299523' => {
                                           'Header' => 'platform.h',
                                           'Line' => '47',
                                           'Param' => {
@@ -9424,7 +9444,7 @@ $VAR1 = {
                                           'Return' => '100',
                                           'ShortName' => 'encode_bios_attribute_update_event_req'
                                         },
-                            '299284' => {
+                            '300629' => {
                                           'Header' => 'file_io.h',
                                           'Line' => '36',
                                           'Param' => {
@@ -9744,6 +9764,7 @@ $VAR1 = {
                                                  'pldm_entity_is_node_parent' => 1,
                                                  'pldm_entity_node_get_remote_container_id' => 1,
                                                  'pldm_find_entity_ref_in_tree' => 1,
+                                                 'pldm_get_entity_from_record_handle' => 1,
                                                  'pldm_instance_db_destroy' => 1,
                                                  'pldm_instance_db_init' => 1,
                                                  'pldm_instance_db_init_default' => 1,
@@ -11256,8 +11277,70 @@ $VAR1 = {
                                        'Size' => '8',
                                        'Type' => 'Pointer'
                                      },
-                          '55043' => {
-                                       'BaseType' => '55060',
+                          '54601' => {
+                                       'BaseType' => '74',
+                                       'Header' => 'types.h',
+                                       'Line' => '37',
+                                       'Name' => '__int8_t',
+                                       'PrivateABI' => 1,
+                                       'Size' => '1',
+                                       'Type' => 'Typedef'
+                                     },
+                          '54632' => {
+                                       'BaseType' => '93',
+                                       'Header' => 'types.h',
+                                       'Line' => '39',
+                                       'Name' => '__int16_t',
+                                       'PrivateABI' => 1,
+                                       'Size' => '2',
+                                       'Type' => 'Typedef'
+                                     },
+                          '54663' => {
+                                       'BaseType' => '100',
+                                       'Header' => 'types.h',
+                                       'Line' => '41',
+                                       'Name' => '__int32_t',
+                                       'PrivateABI' => 1,
+                                       'Size' => '4',
+                                       'Type' => 'Typedef'
+                                     },
+                          '54732' => {
+                                       'BaseType' => '54601',
+                                       'Header' => 'stdint-intn.h',
+                                       'Line' => '24',
+                                       'Name' => 'int8_t',
+                                       'PrivateABI' => 1,
+                                       'Size' => '1',
+                                       'Type' => 'Typedef'
+                                     },
+                          '54744' => {
+                                       'BaseType' => '54632',
+                                       'Header' => 'stdint-intn.h',
+                                       'Line' => '25',
+                                       'Name' => 'int16_t',
+                                       'PrivateABI' => 1,
+                                       'Size' => '2',
+                                       'Type' => 'Typedef'
+                                     },
+                          '54756' => {
+                                       'BaseType' => '54663',
+                                       'Header' => 'stdint-intn.h',
+                                       'Line' => '26',
+                                       'Name' => 'int32_t',
+                                       'PrivateABI' => 1,
+                                       'Size' => '4',
+                                       'Type' => 'Typedef'
+                                     },
+                          '54997' => {
+                                       'BaseType' => '133',
+                                       'Header' => 'pldm_types.h',
+                                       'Line' => '164',
+                                       'Name' => 'real32_t',
+                                       'Size' => '4',
+                                       'Type' => 'Typedef'
+                                     },
+                          '55269' => {
+                                       'BaseType' => '55286',
                                        'Header' => 'pdr.h',
                                        'Line' => '16',
                                        'Name' => 'pldm_pdr',
@@ -11265,14 +11348,14 @@ $VAR1 = {
                                        'Size' => '24',
                                        'Type' => 'Typedef'
                                      },
-                          '55055' => {
-                                       'BaseType' => '55043',
+                          '55281' => {
+                                       'BaseType' => '55269',
                                        'Name' => 'pldm_pdr const',
                                        'Size' => '24',
                                        'Type' => 'Const'
                                      },
-                          '55060' => {
-                                       'Line' => '26',
+                          '55286' => {
+                                       'Line' => '25',
                                        'Memb' => {
                                                    '0' => {
                                                             'name' => 'record_count',
@@ -11287,12 +11370,12 @@ $VAR1 = {
                                                    '2' => {
                                                             'name' => 'first',
                                                             'offset' => '8',
-                                                            'type' => '56473'
+                                                            'type' => '57409'
                                                           },
                                                    '3' => {
                                                             'name' => 'last',
                                                             'offset' => '22',
-                                                            'type' => '56473'
+                                                            'type' => '57409'
                                                           }
                                                  },
                                        'Name' => 'struct pldm_pdr',
@@ -11301,8 +11384,8 @@ $VAR1 = {
                                        'Source' => 'pdr.c',
                                        'Type' => 'Struct'
                                      },
-                          '55126' => {
-                                       'BaseType' => '55143',
+                          '55352' => {
+                                       'BaseType' => '55369',
                                        'Header' => 'pdr.h',
                                        'Line' => '21',
                                        'Name' => 'pldm_pdr_record',
@@ -11310,14 +11393,14 @@ $VAR1 = {
                                        'Size' => '32',
                                        'Type' => 'Typedef'
                                      },
-                          '55138' => {
-                                       'BaseType' => '55126',
+                          '55364' => {
+                                       'BaseType' => '55352',
                                        'Name' => 'pldm_pdr_record const',
                                        'Size' => '32',
                                        'Type' => 'Const'
                                      },
-                          '55143' => {
-                                       'Line' => '17',
+                          '55369' => {
+                                       'Line' => '16',
                                        'Memb' => {
                                                    '0' => {
                                                             'name' => 'record_handle',
@@ -11337,7 +11420,7 @@ $VAR1 = {
                                                    '3' => {
                                                             'name' => 'next',
                                                             'offset' => '22',
-                                                            'type' => '56461'
+                                                            'type' => '57397'
                                                           },
                                                    '4' => {
                                                             'name' => 'is_remote',
@@ -11356,7 +11439,7 @@ $VAR1 = {
                                        'Source' => 'pdr.c',
                                        'Type' => 'Struct'
                                      },
-                          '55235' => {
+                          '55461' => {
                                        'Header' => 'pdr.h',
                                        'Line' => '308',
                                        'Memb' => {
@@ -11380,30 +11463,30 @@ $VAR1 = {
                                        'Size' => '6',
                                        'Type' => 'Struct'
                                      },
-                          '55292' => {
-                                       'BaseType' => '55235',
+                          '55518' => {
+                                       'BaseType' => '55461',
                                        'Header' => 'pdr.h',
                                        'Line' => '312',
                                        'Name' => 'pldm_entity',
                                        'Size' => '6',
                                        'Type' => 'Typedef'
                                      },
-                          '55336' => {
-                                       'BaseType' => '55348',
+                          '55563' => {
+                                       'BaseType' => '55576',
                                        'Header' => 'pdr.h',
-                                       'Line' => '322',
+                                       'Line' => '332',
                                        'Name' => 'pldm_entity_association_tree',
                                        'PrivateABI' => 1,
                                        'Size' => '16',
                                        'Type' => 'Typedef'
                                      },
-                          '55348' => {
-                                       'Line' => '527',
+                          '55576' => {
+                                       'Line' => '589',
                                        'Memb' => {
                                                    '0' => {
                                                             'name' => 'root',
                                                             'offset' => '0',
-                                                            'type' => '56478'
+                                                            'type' => '57414'
                                                           },
                                                    '1' => {
                                                             'name' => 'last_used_container_id',
@@ -11417,33 +11500,33 @@ $VAR1 = {
                                        'Source' => 'pdr.c',
                                        'Type' => 'Struct'
                                      },
-                          '55391' => {
-                                       'BaseType' => '55408',
+                          '55619' => {
+                                       'BaseType' => '55637',
                                        'Header' => 'pdr.h',
-                                       'Line' => '327',
+                                       'Line' => '337',
                                        'Name' => 'pldm_entity_node',
                                        'PrivateABI' => 1,
                                        'Size' => '40',
                                        'Type' => 'Typedef'
                                      },
-                          '55403' => {
-                                       'BaseType' => '55391',
+                          '55632' => {
+                                       'BaseType' => '55619',
                                        'Name' => 'pldm_entity_node const',
                                        'Size' => '40',
                                        'Type' => 'Const'
                                      },
-                          '55408' => {
-                                       'Line' => '532',
+                          '55637' => {
+                                       'Line' => '594',
                                        'Memb' => {
                                                    '0' => {
                                                             'name' => 'entity',
                                                             'offset' => '0',
-                                                            'type' => '55292'
+                                                            'type' => '55518'
                                                           },
                                                    '1' => {
                                                             'name' => 'parent',
                                                             'offset' => '6',
-                                                            'type' => '55292'
+                                                            'type' => '55518'
                                                           },
                                                    '2' => {
                                                             'name' => 'remote_container_id',
@@ -11453,12 +11536,12 @@ $VAR1 = {
                                                    '3' => {
                                                             'name' => 'first_child',
                                                             'offset' => '22',
-                                                            'type' => '56478'
+                                                            'type' => '57414'
                                                           },
                                                    '4' => {
                                                             'name' => 'next_sibling',
                                                             'offset' => '36',
-                                                            'type' => '56478'
+                                                            'type' => '57414'
                                                           },
                                                    '5' => {
                                                             'name' => 'association_type',
@@ -11472,7 +11555,7 @@ $VAR1 = {
                                        'Source' => 'pdr.c',
                                        'Type' => 'Struct'
                                      },
-                          '55679' => {
+                          '55908' => {
                                        'Header' => 'platform.h',
                                        'Line' => '481',
                                        'Memb' => {
@@ -11506,14 +11589,14 @@ $VAR1 = {
                                        'Size' => '10',
                                        'Type' => 'Struct'
                                      },
-                          '56128' => {
+                          '56358' => {
                                        'Header' => 'platform.h',
                                        'Line' => '556',
                                        'Memb' => {
                                                    '0' => {
                                                             'name' => 'hdr',
                                                             'offset' => '0',
-                                                            'type' => '55679'
+                                                            'type' => '55908'
                                                           },
                                                    '1' => {
                                                             'name' => 'terminus_handle',
@@ -11565,14 +11648,14 @@ $VAR1 = {
                                        'Size' => '24',
                                        'Type' => 'Struct'
                                      },
-                          '56282' => {
+                          '56512' => {
                                        'Header' => 'platform.h',
                                        'Line' => '583',
                                        'Memb' => {
                                                    '0' => {
                                                             'name' => 'hdr',
                                                             'offset' => '0',
-                                                            'type' => '55679'
+                                                            'type' => '55908'
                                                           },
                                                    '1' => {
                                                             'name' => 'terminus_handle',
@@ -11629,153 +11712,135 @@ $VAR1 = {
                                        'Size' => '26',
                                        'Type' => 'Struct'
                                      },
-                          '56461' => {
-                                       'BaseType' => '55143',
+                          '56869' => {
+                                       'Header' => 'platform.h',
+                                       'Line' => '674',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'value_u8',
+                                                            'offset' => '0',
+                                                            'type' => '121'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'value_s8',
+                                                            'offset' => '0',
+                                                            'type' => '54732'
+                                                          },
+                                                   '2' => {
+                                                            'name' => 'value_u16',
+                                                            'offset' => '0',
+                                                            'type' => '1011'
+                                                          },
+                                                   '3' => {
+                                                            'name' => 'value_s16',
+                                                            'offset' => '0',
+                                                            'type' => '54744'
+                                                          },
+                                                   '4' => {
+                                                            'name' => 'value_u32',
+                                                            'offset' => '0',
+                                                            'type' => '1023'
+                                                          },
+                                                   '5' => {
+                                                            'name' => 'value_s32',
+                                                            'offset' => '0',
+                                                            'type' => '54756'
+                                                          },
+                                                   '6' => {
+                                                            'name' => 'value_f32',
+                                                            'offset' => '0',
+                                                            'type' => '54997'
+                                                          }
+                                                 },
+                                       'Name' => 'union union_range_field_format',
+                                       'Size' => '4',
+                                       'Type' => 'Union'
+                                     },
+                          '57397' => {
+                                       'BaseType' => '55369',
                                        'Name' => 'struct pldm_pdr_record*',
                                        'Size' => '8',
                                        'Type' => 'Pointer'
                                      },
-                          '56473' => {
-                                       'BaseType' => '55126',
+                          '57409' => {
+                                       'BaseType' => '55352',
                                        'Name' => 'pldm_pdr_record*',
                                        'Size' => '8',
                                        'Type' => 'Pointer'
                                      },
-                          '56478' => {
-                                       'BaseType' => '55391',
+                          '57414' => {
+                                       'BaseType' => '55619',
                                        'Name' => 'pldm_entity_node*',
                                        'Size' => '8',
                                        'Type' => 'Pointer'
                                      },
-                          '63024' => {
-                                       'BaseType' => '55043',
+                          '63960' => {
+                                       'BaseType' => '55269',
                                        'Name' => 'pldm_pdr*',
                                        'Size' => '8',
                                        'Type' => 'Pointer'
                                      },
-                          '63029' => {
-                                       'BaseType' => '55292',
+                          '63965' => {
+                                       'BaseType' => '55518',
                                        'Name' => 'pldm_entity*',
                                        'Size' => '8',
                                        'Type' => 'Pointer'
                                      },
-                          '66898' => {
-                                       'BaseType' => '55055',
+                          '67834' => {
+                                       'BaseType' => '55281',
                                        'Name' => 'pldm_pdr const*',
                                        'Size' => '8',
                                        'Type' => 'Pointer'
                                      },
-                          '66903' => {
+                          '67839' => {
                                        'BaseType' => '805',
                                        'Name' => '_Bool*',
                                        'Size' => '8',
                                        'Type' => 'Pointer'
                                      },
-                          '68374' => {
-                                       'BaseType' => '55138',
+                          '69310' => {
+                                       'BaseType' => '55364',
                                        'Name' => 'pldm_pdr_record const*',
                                        'Size' => '8',
                                        'Type' => 'Pointer'
                                      },
-                          '69266' => {
-                                       'BaseType' => '56128',
+                          '70202' => {
+                                       'BaseType' => '56358',
                                        'Name' => 'struct pldm_state_sensor_pdr*',
                                        'Size' => '8',
                                        'Type' => 'Pointer'
                                      },
-                          '69647' => {
-                                       'BaseType' => '56282',
+                          '70583' => {
+                                       'BaseType' => '56512',
                                        'Name' => 'struct pldm_state_effecter_pdr*',
                                        'Size' => '8',
                                        'Type' => 'Pointer'
                                      },
-                          '82269' => {
-                                       'BaseType' => '63029',
+                          '83205' => {
+                                       'BaseType' => '63965',
                                        'Name' => 'pldm_entity**',
                                        'Size' => '8',
                                        'Type' => 'Pointer'
                                      },
-                          '82328' => {
-                                       'BaseType' => '55336',
+                          '83264' => {
+                                       'BaseType' => '55563',
                                        'Name' => 'pldm_entity_association_tree*',
                                        'Size' => '8',
                                        'Type' => 'Pointer'
                                      },
-                          '82775' => {
-                                       'BaseType' => '56478',
+                          '83711' => {
+                                       'BaseType' => '57414',
                                        'Name' => 'pldm_entity_node**',
                                        'Size' => '8',
                                        'Type' => 'Pointer'
                                      },
-                          '89218' => {
-                                       'BaseType' => '55403',
+                          '90154' => {
+                                       'BaseType' => '55632',
                                        'Name' => 'pldm_entity_node const*',
                                        'Size' => '8',
                                        'Type' => 'Pointer'
                                      },
-                          '95283' => {
-                                       'BaseType' => '74',
-                                       'Header' => 'types.h',
-                                       'Line' => '37',
-                                       'Name' => '__int8_t',
-                                       'PrivateABI' => 1,
-                                       'Size' => '1',
-                                       'Type' => 'Typedef'
-                                     },
-                          '95314' => {
-                                       'BaseType' => '93',
-                                       'Header' => 'types.h',
-                                       'Line' => '39',
-                                       'Name' => '__int16_t',
-                                       'PrivateABI' => 1,
-                                       'Size' => '2',
-                                       'Type' => 'Typedef'
-                                     },
-                          '95345' => {
-                                       'BaseType' => '100',
-                                       'Header' => 'types.h',
-                                       'Line' => '41',
-                                       'Name' => '__int32_t',
-                                       'PrivateABI' => 1,
-                                       'Size' => '4',
-                                       'Type' => 'Typedef'
-                                     },
-                          '95424' => {
-                                       'BaseType' => '95283',
-                                       'Header' => 'stdint-intn.h',
-                                       'Line' => '24',
-                                       'Name' => 'int8_t',
-                                       'PrivateABI' => 1,
-                                       'Size' => '1',
-                                       'Type' => 'Typedef'
-                                     },
-                          '95436' => {
-                                       'BaseType' => '95314',
-                                       'Header' => 'stdint-intn.h',
-                                       'Line' => '25',
-                                       'Name' => 'int16_t',
-                                       'PrivateABI' => 1,
-                                       'Size' => '2',
-                                       'Type' => 'Typedef'
-                                     },
-                          '95448' => {
-                                       'BaseType' => '95345',
-                                       'Header' => 'stdint-intn.h',
-                                       'Line' => '26',
-                                       'Name' => 'int32_t',
-                                       'PrivateABI' => 1,
-                                       'Size' => '4',
-                                       'Type' => 'Typedef'
-                                     },
-                          '95713' => {
-                                       'BaseType' => '133',
-                                       'Header' => 'pldm_types.h',
-                                       'Line' => '164',
-                                       'Name' => 'real32_t',
-                                       'Size' => '4',
-                                       'Type' => 'Typedef'
-                                     },
-                          '96947' => {
+                          '98292' => {
                                        'Header' => 'platform.h',
                                        'Line' => '259',
                                        'Memb' => {
@@ -11796,13 +11861,13 @@ $VAR1 = {
                                        'Size' => '4',
                                        'Type' => 'Enum'
                                      },
-                          '96981' => {
-                                       'BaseType' => '96947',
+                          '98326' => {
+                                       'BaseType' => '98292',
                                        'Name' => 'enum sensor_event_class_states const',
                                        'Size' => '4',
                                        'Type' => 'Const'
                                      },
-                          '97427' => {
+                          '98772' => {
                                        'Header' => 'platform.h',
                                        'Line' => '573',
                                        'Memb' => {
@@ -11819,70 +11884,26 @@ $VAR1 = {
                                                    '2' => {
                                                             'name' => 'states',
                                                             'offset' => '3',
-                                                            'type' => '97485'
+                                                            'type' => '98830'
                                                           }
                                                  },
                                        'Name' => 'struct state_sensor_possible_states',
                                        'Size' => '4',
                                        'Type' => 'Struct'
                                      },
-                          '97480' => {
-                                       'BaseType' => '97427',
+                          '98825' => {
+                                       'BaseType' => '98772',
                                        'Name' => 'struct state_sensor_possible_states const',
                                        'Size' => '4',
                                        'Type' => 'Const'
                                      },
-                          '97485' => {
+                          '98830' => {
                                        'BaseType' => '2776',
                                        'Name' => 'bitfield8_t[1]',
                                        'Size' => '1',
                                        'Type' => 'Array'
                                      },
-                          '97846' => {
-                                       'Header' => 'platform.h',
-                                       'Line' => '674',
-                                       'Memb' => {
-                                                   '0' => {
-                                                            'name' => 'value_u8',
-                                                            'offset' => '0',
-                                                            'type' => '121'
-                                                          },
-                                                   '1' => {
-                                                            'name' => 'value_s8',
-                                                            'offset' => '0',
-                                                            'type' => '95424'
-                                                          },
-                                                   '2' => {
-                                                            'name' => 'value_u16',
-                                                            'offset' => '0',
-                                                            'type' => '1011'
-                                                          },
-                                                   '3' => {
-                                                            'name' => 'value_s16',
-                                                            'offset' => '0',
-                                                            'type' => '95436'
-                                                          },
-                                                   '4' => {
-                                                            'name' => 'value_u32',
-                                                            'offset' => '0',
-                                                            'type' => '1023'
-                                                          },
-                                                   '5' => {
-                                                            'name' => 'value_s32',
-                                                            'offset' => '0',
-                                                            'type' => '95448'
-                                                          },
-                                                   '6' => {
-                                                            'name' => 'value_f32',
-                                                            'offset' => '0',
-                                                            'type' => '95713'
-                                                          }
-                                                 },
-                                       'Name' => 'union union_range_field_format',
-                                       'Size' => '4',
-                                       'Type' => 'Union'
-                                     },
-                          '98409' => {
+                          '99754' => {
                                        'Header' => 'platform.h',
                                        'Line' => '731',
                                        'Memb' => {
@@ -11894,7 +11915,7 @@ $VAR1 = {
                                                    '1' => {
                                                             'name' => 'value_s8',
                                                             'offset' => '0',
-                                                            'type' => '95424'
+                                                            'type' => '54732'
                                                           },
                                                    '2' => {
                                                             'name' => 'value_u16',
@@ -11904,7 +11925,7 @@ $VAR1 = {
                                                    '3' => {
                                                             'name' => 'value_s16',
                                                             'offset' => '0',
-                                                            'type' => '95436'
+                                                            'type' => '54744'
                                                           },
                                                    '4' => {
                                                             'name' => 'value_u32',
@@ -11914,14 +11935,14 @@ $VAR1 = {
                                                    '5' => {
                                                             'name' => 'value_s32',
                                                             'offset' => '0',
-                                                            'type' => '95448'
+                                                            'type' => '54756'
                                                           }
                                                  },
                                        'Name' => 'union union_sensor_data_size',
                                        'Size' => '4',
                                        'Type' => 'Union'
                                      },
-                          '98421' => {
+                          '99766' => {
                                        'Header' => 'platform.h',
                                        'Line' => '738',
                                        'Memb' => {
@@ -11955,7 +11976,7 @@ $VAR1 = {
                                        'Size' => '12',
                                        'Type' => 'Struct'
                                      },
-                          '98500' => {
+                          '99845' => {
                                        'Header' => 'platform.h',
                                        'Line' => '756',
                                        'Memb' => {
@@ -11974,14 +11995,14 @@ $VAR1 = {
                                        'Size' => '2',
                                        'Type' => 'Union'
                                      },
-                          '98534' => {
+                          '99879' => {
                                        'Header' => 'platform.h',
                                        'Line' => '751',
                                        'Memb' => {
                                                    '0' => {
                                                             'name' => 'hdr',
                                                             'offset' => '0',
-                                                            'type' => '98421'
+                                                            'type' => '99766'
                                                           },
                                                    '1' => {
                                                             'name' => 'terminus_handle',
@@ -12001,7 +12022,7 @@ $VAR1 = {
                                                    '4' => {
                                                             'name' => 'unnamed0',
                                                             'offset' => '24',
-                                                            'type' => '98500'
+                                                            'type' => '99845'
                                                           },
                                                    '5' => {
                                                             'name' => 'container_id',
@@ -12026,7 +12047,7 @@ $VAR1 = {
                                                    '9' => {
                                                             'name' => 'unit_modifier',
                                                             'offset' => '37',
-                                                            'type' => '95424'
+                                                            'type' => '54732'
                                                           },
                                                    '10' => {
                                                              'name' => 'rate_unit',
@@ -12046,7 +12067,7 @@ $VAR1 = {
                                                    '13' => {
                                                              'name' => 'aux_unit_modifier',
                                                              'offset' => '41',
-                                                             'type' => '95424'
+                                                             'type' => '54732'
                                                            },
                                                    '14' => {
                                                              'name' => 'aux_rate_unit',
@@ -12076,12 +12097,12 @@ $VAR1 = {
                                                    '19' => {
                                                              'name' => 'resolution',
                                                              'offset' => '54',
-                                                             'type' => '95713'
+                                                             'type' => '54997'
                                                            },
                                                    '20' => {
                                                              'name' => 'offset',
                                                              'offset' => '64',
-                                                             'type' => '95713'
+                                                             'type' => '54997'
                                                            },
                                                    '21' => {
                                                              'name' => 'accuracy',
@@ -12101,7 +12122,7 @@ $VAR1 = {
                                                    '24' => {
                                                              'name' => 'hysteresis',
                                                              'offset' => '72',
-                                                             'type' => '98409'
+                                                             'type' => '99754'
                                                            },
                                                    '25' => {
                                                              'name' => 'supported_thresholds',
@@ -12116,22 +12137,22 @@ $VAR1 = {
                                                    '27' => {
                                                              'name' => 'state_transition_interval',
                                                              'offset' => '86',
-                                                             'type' => '95713'
+                                                             'type' => '54997'
                                                            },
                                                    '28' => {
                                                              'name' => 'update_interval',
                                                              'offset' => '96',
-                                                             'type' => '95713'
+                                                             'type' => '54997'
                                                            },
                                                    '29' => {
                                                              'name' => 'max_readable',
                                                              'offset' => '100',
-                                                             'type' => '98409'
+                                                             'type' => '99754'
                                                            },
                                                    '30' => {
                                                              'name' => 'min_readable',
                                                              'offset' => '104',
-                                                             'type' => '98409'
+                                                             'type' => '99754'
                                                            },
                                                    '31' => {
                                                              'name' => 'range_field_format',
@@ -12146,180 +12167,180 @@ $VAR1 = {
                                                    '33' => {
                                                              'name' => 'nominal_value',
                                                              'offset' => '118',
-                                                             'type' => '97846'
+                                                             'type' => '56869'
                                                            },
                                                    '34' => {
                                                              'name' => 'normal_max',
                                                              'offset' => '128',
-                                                             'type' => '97846'
+                                                             'type' => '56869'
                                                            },
                                                    '35' => {
                                                              'name' => 'normal_min',
                                                              'offset' => '132',
-                                                             'type' => '97846'
+                                                             'type' => '56869'
                                                            },
                                                    '36' => {
                                                              'name' => 'warning_high',
                                                              'offset' => '136',
-                                                             'type' => '97846'
+                                                             'type' => '56869'
                                                            },
                                                    '37' => {
                                                              'name' => 'warning_low',
                                                              'offset' => '146',
-                                                             'type' => '97846'
+                                                             'type' => '56869'
                                                            },
                                                    '38' => {
                                                              'name' => 'critical_high',
                                                              'offset' => '150',
-                                                             'type' => '97846'
+                                                             'type' => '56869'
                                                            },
                                                    '39' => {
                                                              'name' => 'critical_low',
                                                              'offset' => '256',
-                                                             'type' => '97846'
+                                                             'type' => '56869'
                                                            },
                                                    '40' => {
                                                              'name' => 'fatal_high',
                                                              'offset' => '260',
-                                                             'type' => '97846'
+                                                             'type' => '56869'
                                                            },
                                                    '41' => {
                                                              'name' => 'fatal_low',
                                                              'offset' => '264',
-                                                             'type' => '97846'
+                                                             'type' => '56869'
                                                            }
                                                  },
                                        'Name' => 'struct pldm_numeric_sensor_value_pdr',
                                        'Size' => '112',
                                        'Type' => 'Struct'
                                      },
-                          '99087' => {
-                                       'Header' => 'platform.h',
-                                       'Line' => '803',
-                                       'Memb' => {
-                                                   '0' => {
-                                                            'name' => 'state_set_id',
-                                                            'offset' => '0',
-                                                            'type' => '1011'
-                                                          },
-                                                   '1' => {
-                                                            'name' => 'possible_states_size',
-                                                            'offset' => '2',
-                                                            'type' => '121'
-                                                          },
-                                                   '2' => {
-                                                            'name' => 'states',
-                                                            'offset' => '3',
-                                                            'type' => '97485'
-                                                          }
-                                                 },
-                                       'Name' => 'struct state_effecter_possible_states',
-                                       'Size' => '4',
-                                       'Type' => 'Struct'
-                                     },
-                          '99140' => {
-                                       'BaseType' => '99087',
-                                       'Name' => 'struct state_effecter_possible_states const',
-                                       'Size' => '4',
-                                       'Type' => 'Const'
-                                     },
-                          '99145' => {
-                                       'Header' => 'platform.h',
-                                       'Line' => '851',
-                                       'Memb' => {
-                                                   '0' => {
-                                                            'name' => 'set_request',
-                                                            'offset' => '0',
-                                                            'type' => '121'
-                                                          },
-                                                   '1' => {
-                                                            'name' => 'effecter_state',
-                                                            'offset' => '1',
-                                                            'type' => '121'
-                                                          }
-                                                 },
-                                       'Name' => 'struct state_field_for_state_effecter_set',
-                                       'Size' => '2',
-                                       'Type' => 'Struct'
-                                     },
-                          '99185' => {
-                                       'BaseType' => '99145',
-                                       'Header' => 'platform.h',
-                                       'Line' => '854',
-                                       'Name' => 'set_effecter_state_field',
-                                       'Size' => '2',
-                                       'Type' => 'Typedef'
-                                     },
-                          '99197' => {
-                                       'Header' => 'platform.h',
-                                       'Line' => '860',
-                                       'Memb' => {
-                                                   '0' => {
-                                                            'name' => 'sensor_op_state',
-                                                            'offset' => '0',
-                                                            'type' => '121'
-                                                          },
-                                                   '1' => {
-                                                            'name' => 'present_state',
-                                                            'offset' => '1',
-                                                            'type' => '121'
-                                                          },
-                                                   '2' => {
-                                                            'name' => 'previous_state',
-                                                            'offset' => '2',
-                                                            'type' => '121'
-                                                          },
-                                                   '3' => {
-                                                            'name' => 'event_state',
-                                                            'offset' => '3',
-                                                            'type' => '121'
-                                                          }
-                                                 },
-                                       'Name' => 'struct state_field_for_get_state_sensor_readings',
-                                       'Size' => '4',
-                                       'Type' => 'Struct'
-                                     },
-                          '99263' => {
-                                       'BaseType' => '99197',
-                                       'Header' => 'platform.h',
-                                       'Line' => '868',
-                                       'Name' => 'get_sensor_state_field',
-                                       'Size' => '4',
-                                       'Type' => 'Typedef'
-                                     },
-                          '99275' => {
-                                       'Header' => 'platform.h',
-                                       'Line' => '874',
-                                       'Memb' => {
-                                                   '0' => {
-                                                            'name' => 'effecter_op_state',
-                                                            'offset' => '0',
-                                                            'type' => '121'
-                                                          },
-                                                   '1' => {
-                                                            'name' => 'pending_state',
-                                                            'offset' => '1',
-                                                            'type' => '121'
-                                                          },
-                                                   '2' => {
-                                                            'name' => 'present_state',
-                                                            'offset' => '2',
-                                                            'type' => '121'
-                                                          }
-                                                 },
-                                       'Name' => 'struct state_field_for_get_state_effecter_states',
-                                       'Size' => '3',
-                                       'Type' => 'Struct'
-                                     },
-                          '99328' => {
-                                       'BaseType' => '99275',
-                                       'Header' => 'platform.h',
-                                       'Line' => '878',
-                                       'Name' => 'get_effecter_state_field',
-                                       'Size' => '3',
-                                       'Type' => 'Typedef'
-                                     },
-                          '100009' => {
+                          '100432' => {
+                                        'Header' => 'platform.h',
+                                        'Line' => '803',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'state_set_id',
+                                                             'offset' => '0',
+                                                             'type' => '1011'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 'possible_states_size',
+                                                             'offset' => '2',
+                                                             'type' => '121'
+                                                           },
+                                                    '2' => {
+                                                             'name' => 'states',
+                                                             'offset' => '3',
+                                                             'type' => '98830'
+                                                           }
+                                                  },
+                                        'Name' => 'struct state_effecter_possible_states',
+                                        'Size' => '4',
+                                        'Type' => 'Struct'
+                                      },
+                          '100485' => {
+                                        'BaseType' => '100432',
+                                        'Name' => 'struct state_effecter_possible_states const',
+                                        'Size' => '4',
+                                        'Type' => 'Const'
+                                      },
+                          '100490' => {
+                                        'Header' => 'platform.h',
+                                        'Line' => '851',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'set_request',
+                                                             'offset' => '0',
+                                                             'type' => '121'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 'effecter_state',
+                                                             'offset' => '1',
+                                                             'type' => '121'
+                                                           }
+                                                  },
+                                        'Name' => 'struct state_field_for_state_effecter_set',
+                                        'Size' => '2',
+                                        'Type' => 'Struct'
+                                      },
+                          '100530' => {
+                                        'BaseType' => '100490',
+                                        'Header' => 'platform.h',
+                                        'Line' => '854',
+                                        'Name' => 'set_effecter_state_field',
+                                        'Size' => '2',
+                                        'Type' => 'Typedef'
+                                      },
+                          '100542' => {
+                                        'Header' => 'platform.h',
+                                        'Line' => '860',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'sensor_op_state',
+                                                             'offset' => '0',
+                                                             'type' => '121'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 'present_state',
+                                                             'offset' => '1',
+                                                             'type' => '121'
+                                                           },
+                                                    '2' => {
+                                                             'name' => 'previous_state',
+                                                             'offset' => '2',
+                                                             'type' => '121'
+                                                           },
+                                                    '3' => {
+                                                             'name' => 'event_state',
+                                                             'offset' => '3',
+                                                             'type' => '121'
+                                                           }
+                                                  },
+                                        'Name' => 'struct state_field_for_get_state_sensor_readings',
+                                        'Size' => '4',
+                                        'Type' => 'Struct'
+                                      },
+                          '100608' => {
+                                        'BaseType' => '100542',
+                                        'Header' => 'platform.h',
+                                        'Line' => '868',
+                                        'Name' => 'get_sensor_state_field',
+                                        'Size' => '4',
+                                        'Type' => 'Typedef'
+                                      },
+                          '100620' => {
+                                        'Header' => 'platform.h',
+                                        'Line' => '874',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'effecter_op_state',
+                                                             'offset' => '0',
+                                                             'type' => '121'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 'pending_state',
+                                                             'offset' => '1',
+                                                             'type' => '121'
+                                                           },
+                                                    '2' => {
+                                                             'name' => 'present_state',
+                                                             'offset' => '2',
+                                                             'type' => '121'
+                                                           }
+                                                  },
+                                        'Name' => 'struct state_field_for_get_state_effecter_states',
+                                        'Size' => '3',
+                                        'Type' => 'Struct'
+                                      },
+                          '100673' => {
+                                        'BaseType' => '100620',
+                                        'Header' => 'platform.h',
+                                        'Line' => '878',
+                                        'Name' => 'get_effecter_state_field',
+                                        'Size' => '3',
+                                        'Type' => 'Typedef'
+                                      },
+                          '101354' => {
                                         'Header' => 'platform.h',
                                         'Line' => '1023',
                                         'Memb' => {
@@ -12336,20 +12357,20 @@ $VAR1 = {
                                                     '2' => {
                                                              'name' => 'field',
                                                              'offset' => '2',
-                                                             'type' => '100062'
+                                                             'type' => '101407'
                                                            }
                                                   },
                                         'Name' => 'struct pldm_get_state_effecter_states_resp',
                                         'Size' => '26',
                                         'Type' => 'Struct'
                                       },
-                          '100062' => {
-                                        'BaseType' => '99328',
+                          '101407' => {
+                                        'BaseType' => '100673',
                                         'Name' => 'get_effecter_state_field[8]',
                                         'Size' => '24',
                                         'Type' => 'Array'
                                       },
-                          '100078' => {
+                          '101423' => {
                                         'Header' => 'platform.h',
                                         'Line' => '1033',
                                         'Memb' => {
@@ -12373,7 +12394,7 @@ $VAR1 = {
                                         'Size' => '4',
                                         'Type' => 'Struct'
                                       },
-                          '100290' => {
+                          '101635' => {
                                         'Header' => 'platform.h',
                                         'Line' => '1114',
                                         'Memb' => {
@@ -12397,109 +12418,109 @@ $VAR1 = {
                                         'Size' => '3',
                                         'Type' => 'Struct'
                                       },
-                          '102373' => {
-                                        'BaseType' => '100009',
+                          '103718' => {
+                                        'BaseType' => '101354',
                                         'Name' => 'struct pldm_get_state_effecter_states_resp*',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '158891' => {
+                          '160236' => {
                                         'BaseType' => '13058',
                                         'Name' => 'size_t*const',
                                         'Size' => '8',
                                         'Type' => 'Const'
                                       },
-                          '162501' => {
-                                        'BaseType' => '162511',
+                          '163846' => {
+                                        'BaseType' => '163856',
                                         'Name' => 'uint32_t const*const*',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '162506' => {
+                          '163851' => {
                                         'BaseType' => '29980',
                                         'Name' => 'uint32_t const*',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '162511' => {
-                                        'BaseType' => '162506',
+                          '163856' => {
+                                        'BaseType' => '163851',
                                         'Name' => 'uint32_t const*const',
                                         'Size' => '8',
                                         'Type' => 'Const'
                                       },
-                          '162516' => {
-                                        'BaseType' => '100290',
+                          '163861' => {
+                                        'BaseType' => '101635',
                                         'Name' => 'struct pldm_pdr_repository_chg_event_data*',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '227018' => {
-                                        'BaseType' => '98534',
+                          '228363' => {
+                                        'BaseType' => '99879',
                                         'Name' => 'struct pldm_numeric_sensor_value_pdr*',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '242412' => {
-                                        'BaseType' => '100078',
+                          '243757' => {
+                                        'BaseType' => '101423',
                                         'Name' => 'struct pldm_sensor_event_data*',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '242417' => {
-                                        'BaseType' => '242412',
+                          '243762' => {
+                                        'BaseType' => '243757',
                                         'Name' => 'struct pldm_sensor_event_data*const',
                                         'Size' => '8',
                                         'Type' => 'Const'
                                       },
-                          '245351' => {
-                                        'BaseType' => '99263',
+                          '246696' => {
+                                        'BaseType' => '100608',
                                         'Name' => 'get_sensor_state_field*',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '258611' => {
-                                        'BaseType' => '99185',
+                          '259956' => {
+                                        'BaseType' => '100530',
                                         'Name' => 'set_effecter_state_field*',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '259582' => {
-                                        'BaseType' => '69266',
+                          '260927' => {
+                                        'BaseType' => '70202',
                                         'Name' => 'struct pldm_state_sensor_pdr*const',
                                         'Size' => '8',
                                         'Type' => 'Const'
                                       },
-                          '259587' => {
-                                        'BaseType' => '97480',
+                          '260932' => {
+                                        'BaseType' => '98825',
                                         'Name' => 'struct state_sensor_possible_states const*',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '259592' => {
-                                        'BaseType' => '259587',
+                          '260937' => {
+                                        'BaseType' => '260932',
                                         'Name' => 'struct state_sensor_possible_states const*const',
                                         'Size' => '8',
                                         'Type' => 'Const'
                                       },
-                          '259986' => {
-                                        'BaseType' => '69647',
+                          '261331' => {
+                                        'BaseType' => '70583',
                                         'Name' => 'struct pldm_state_effecter_pdr*const',
                                         'Size' => '8',
                                         'Type' => 'Const'
                                       },
-                          '259991' => {
-                                        'BaseType' => '99140',
+                          '261336' => {
+                                        'BaseType' => '100485',
                                         'Name' => 'struct state_effecter_possible_states const*',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '259996' => {
-                                        'BaseType' => '259991',
+                          '261341' => {
+                                        'BaseType' => '261336',
                                         'Name' => 'struct state_effecter_possible_states const*const',
                                         'Size' => '8',
                                         'Type' => 'Const'
                                       },
-                          '265676' => {
+                          '267021' => {
                                         'Line' => '20',
                                         'Memb' => {
                                                     '0' => {
@@ -12519,13 +12540,13 @@ $VAR1 = {
                                         'Source' => 'instance-id.c',
                                         'Type' => 'Struct'
                                       },
-                          '265715' => {
+                          '267060' => {
                                         'Line' => '25',
                                         'Memb' => {
                                                     '0' => {
                                                              'name' => 'state',
                                                              'offset' => '0',
-                                                             'type' => '265757'
+                                                             'type' => '267102'
                                                            },
                                                     '1' => {
                                                              'name' => 'lock_db_fd',
@@ -12539,31 +12560,31 @@ $VAR1 = {
                                         'Source' => 'instance-id.c',
                                         'Type' => 'Struct'
                                       },
-                          '265757' => {
-                                        'BaseType' => '265676',
+                          '267102' => {
+                                        'BaseType' => '267021',
                                         'Name' => 'struct pldm_tid_state[256]',
                                         'Size' => '2048',
                                         'Type' => 'Array'
                                       },
-                          '266227' => {
-                                        'BaseType' => '265715',
+                          '267572' => {
+                                        'BaseType' => '267060',
                                         'Name' => 'struct pldm_instance_db*',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '266652' => {
+                          '267997' => {
                                         'BaseType' => '187',
                                         'Name' => 'pldm_instance_id_t*',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '266828' => {
-                                        'BaseType' => '266227',
+                          '268173' => {
+                                        'BaseType' => '267572',
                                         'Name' => 'struct pldm_instance_db**',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '267585' => {
+                          '268930' => {
                                         'BaseType' => '121',
                                         'Header' => 'pldm.h',
                                         'Line' => '13',
@@ -12571,7 +12592,7 @@ $VAR1 = {
                                         'Size' => '1',
                                         'Type' => 'Typedef'
                                       },
-                          '267700' => {
+                          '269045' => {
                                         'BaseType' => '284',
                                         'Header' => 'pldm.h',
                                         'Line' => '30',
@@ -12579,13 +12600,13 @@ $VAR1 = {
                                         'Size' => '4',
                                         'Type' => 'Typedef'
                                       },
-                          '267718' => {
+                          '269063' => {
                                         'Line' => '25',
                                         'Memb' => {
                                                     '0' => {
                                                              'name' => 'transport',
                                                              'offset' => '0',
-                                                             'type' => '267791'
+                                                             'type' => '269136'
                                                            },
                                                     '1' => {
                                                              'name' => 'socket',
@@ -12595,12 +12616,12 @@ $VAR1 = {
                                                     '2' => {
                                                              'name' => 'tid_eid_map',
                                                              'offset' => '68',
-                                                             'type' => '271423'
+                                                             'type' => '272768'
                                                            },
                                                     '3' => {
                                                              'name' => 'socket_send_buf',
                                                              'offset' => '768',
-                                                             'type' => '270372'
+                                                             'type' => '271717'
                                                            }
                                                   },
                                         'Name' => 'struct pldm_transport_mctp_demux',
@@ -12609,19 +12630,19 @@ $VAR1 = {
                                         'Source' => 'mctp-demux.c',
                                         'Type' => 'Struct'
                                       },
-                          '267744' => {
-                                        'BaseType' => '267718',
+                          '269089' => {
+                                        'BaseType' => '269063',
                                         'Name' => 'struct pldm_transport_mctp_demux*',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '267786' => {
-                                        'BaseType' => '267791',
+                          '269131' => {
+                                        'BaseType' => '269136',
                                         'Name' => 'struct pldm_transport*',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '267791' => {
+                          '269136' => {
                                         'Header' => 'transport.h',
                                         'Line' => '18',
                                         'Memb' => {
@@ -12638,17 +12659,17 @@ $VAR1 = {
                                                     '2' => {
                                                              'name' => 'recv',
                                                              'offset' => '22',
-                                                             'type' => '270683'
+                                                             'type' => '272028'
                                                            },
                                                     '3' => {
                                                              'name' => 'send',
                                                              'offset' => '36',
-                                                             'type' => '270724'
+                                                             'type' => '272069'
                                                            },
                                                     '4' => {
                                                              'name' => 'init_pollfd',
                                                              'offset' => '50',
-                                                             'type' => '270804'
+                                                             'type' => '272149'
                                                            }
                                                   },
                                         'Name' => 'struct pldm_transport',
@@ -12656,19 +12677,19 @@ $VAR1 = {
                                         'Size' => '40',
                                         'Type' => 'Struct'
                                       },
-                          '267927' => {
+                          '269272' => {
                                         'BaseType' => '175',
                                         'Name' => 'pldm_tid_t*',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '268030' => {
-                                        'BaseType' => '267744',
+                          '269375' => {
+                                        'BaseType' => '269089',
                                         'Name' => 'struct pldm_transport_mctp_demux**',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '270092' => {
+                          '271437' => {
                                         'BaseType' => '46',
                                         'Header' => 'int-ll64.h',
                                         'Line' => '21',
@@ -12677,7 +12698,7 @@ $VAR1 = {
                                         'Size' => '1',
                                         'Type' => 'Typedef'
                                       },
-                          '270104' => {
+                          '271449' => {
                                         'BaseType' => '53',
                                         'Header' => 'int-ll64.h',
                                         'Line' => '24',
@@ -12686,7 +12707,7 @@ $VAR1 = {
                                         'Size' => '2',
                                         'Type' => 'Typedef'
                                       },
-                          '270372' => {
+                          '271717' => {
                                         'Header' => 'socket.h',
                                         'Line' => '5',
                                         'Memb' => {
@@ -12711,14 +12732,14 @@ $VAR1 = {
                                         'Size' => '12',
                                         'Type' => 'Struct'
                                       },
-                          '270683' => {
+                          '272028' => {
                                         'Name' => 'pldm_requester_rc_t(*)(struct pldm_transport*, pldm_tid_t*, void**, size_t*)',
                                         'Param' => {
                                                      '0' => {
-                                                              'type' => '267786'
+                                                              'type' => '269131'
                                                             },
                                                      '1' => {
-                                                              'type' => '267927'
+                                                              'type' => '269272'
                                                             },
                                                      '2' => {
                                                               'type' => '47696'
@@ -12727,15 +12748,15 @@ $VAR1 = {
                                                               'type' => '13058'
                                                             }
                                                    },
-                                        'Return' => '267700',
+                                        'Return' => '269045',
                                         'Size' => '8',
                                         'Type' => 'FuncPtr'
                                       },
-                          '270724' => {
+                          '272069' => {
                                         'Name' => 'pldm_requester_rc_t(*)(struct pldm_transport*, pldm_tid_t, void const*, size_t)',
                                         'Param' => {
                                                      '0' => {
-                                                              'type' => '267786'
+                                                              'type' => '269131'
                                                             },
                                                      '1' => {
                                                               'type' => '175'
@@ -12747,17 +12768,17 @@ $VAR1 = {
                                                               'type' => '1145'
                                                             }
                                                    },
-                                        'Return' => '267700',
+                                        'Return' => '269045',
                                         'Size' => '8',
                                         'Type' => 'FuncPtr'
                                       },
-                          '270749' => {
-                                        'BaseType' => '270754',
+                          '272094' => {
+                                        'BaseType' => '272099',
                                         'Name' => 'struct pollfd*',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '270754' => {
+                          '272099' => {
                                         'Header' => 'poll.h',
                                         'Line' => '36',
                                         'Memb' => {
@@ -12782,21 +12803,21 @@ $VAR1 = {
                                         'Size' => '8',
                                         'Type' => 'Struct'
                                       },
-                          '270804' => {
+                          '272149' => {
                                         'Name' => 'int(*)(struct pldm_transport*, struct pollfd*)',
                                         'Param' => {
                                                      '0' => {
-                                                              'type' => '267786'
+                                                              'type' => '269131'
                                                             },
                                                      '1' => {
-                                                              'type' => '270749'
+                                                              'type' => '272094'
                                                             }
                                                    },
                                         'Return' => '100',
                                         'Size' => '8',
                                         'Type' => 'FuncPtr'
                                       },
-                          '270809' => {
+                          '272154' => {
                                         'BaseType' => '53',
                                         'Header' => 'socket.h',
                                         'Line' => '10',
@@ -12805,14 +12826,14 @@ $VAR1 = {
                                         'Size' => '2',
                                         'Type' => 'Typedef'
                                       },
-                          '271157' => {
+                          '272502' => {
                                         'Header' => 'mctp.h',
                                         'Line' => '18',
                                         'Memb' => {
                                                     '0' => {
                                                              'name' => 's_addr',
                                                              'offset' => '0',
-                                                             'type' => '267585'
+                                                             'type' => '268930'
                                                            }
                                                   },
                                         'Name' => 'struct mctp_addr',
@@ -12820,19 +12841,19 @@ $VAR1 = {
                                         'Size' => '1',
                                         'Type' => 'Struct'
                                       },
-                          '271183' => {
+                          '272528' => {
                                         'Header' => 'mctp.h',
                                         'Line' => '22',
                                         'Memb' => {
                                                     '0' => {
                                                              'name' => 'smctp_family',
                                                              'offset' => '0',
-                                                             'type' => '270809'
+                                                             'type' => '272154'
                                                            },
                                                     '1' => {
                                                              'name' => '__smctp_pad0',
                                                              'offset' => '2',
-                                                             'type' => '270104'
+                                                             'type' => '271449'
                                                            },
                                                     '2' => {
                                                              'name' => 'smctp_network',
@@ -12842,22 +12863,22 @@ $VAR1 = {
                                                     '3' => {
                                                              'name' => 'smctp_addr',
                                                              'offset' => '8',
-                                                             'type' => '271157'
+                                                             'type' => '272502'
                                                            },
                                                     '4' => {
                                                              'name' => 'smctp_type',
                                                              'offset' => '9',
-                                                             'type' => '270092'
+                                                             'type' => '271437'
                                                            },
                                                     '5' => {
                                                              'name' => 'smctp_tag',
                                                              'offset' => '16',
-                                                             'type' => '270092'
+                                                             'type' => '271437'
                                                            },
                                                     '6' => {
                                                              'name' => '__smctp_pad1',
                                                              'offset' => '17',
-                                                             'type' => '270092'
+                                                             'type' => '271437'
                                                            }
                                                   },
                                         'Name' => 'struct sockaddr_mctp',
@@ -12865,19 +12886,19 @@ $VAR1 = {
                                         'Size' => '12',
                                         'Type' => 'Struct'
                                       },
-                          '271287' => {
-                                        'BaseType' => '271183',
+                          '272632' => {
+                                        'BaseType' => '272528',
                                         'Name' => 'struct sockaddr_mctp const',
                                         'Size' => '12',
                                         'Type' => 'Const'
                                       },
-                          '271330' => {
+                          '272675' => {
                                         'Line' => '34',
                                         'Memb' => {
                                                     '0' => {
                                                              'name' => 'transport',
                                                              'offset' => '0',
-                                                             'type' => '267791'
+                                                             'type' => '269136'
                                                            },
                                                     '1' => {
                                                              'name' => 'socket',
@@ -12887,12 +12908,12 @@ $VAR1 = {
                                                     '2' => {
                                                              'name' => 'tid_eid_map',
                                                              'offset' => '68',
-                                                             'type' => '271423'
+                                                             'type' => '272768'
                                                            },
                                                     '3' => {
                                                              'name' => 'socket_send_buf',
                                                              'offset' => '768',
-                                                             'type' => '270372'
+                                                             'type' => '271717'
                                                            },
                                                     '4' => {
                                                              'name' => 'bound',
@@ -12911,26 +12932,26 @@ $VAR1 = {
                                         'Source' => 'af-mctp.c',
                                         'Type' => 'Struct'
                                       },
-                          '271423' => {
+                          '272768' => {
                                         'BaseType' => '175',
                                         'Name' => 'pldm_tid_t[256]',
                                         'Size' => '256',
                                         'Type' => 'Array'
                                       },
-                          '272239' => {
-                                        'BaseType' => '271330',
+                          '273584' => {
+                                        'BaseType' => '272675',
                                         'Name' => 'struct pldm_transport_af_mctp*',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '272244' => {
-                                        'BaseType' => '271287',
+                          '273589' => {
+                                        'BaseType' => '272632',
                                         'Name' => 'struct sockaddr_mctp const*',
                                         'Size' => '8',
                                         'Type' => 'Pointer'
                                       },
-                          '272557' => {
-                                        'BaseType' => '272239',
+                          '273902' => {
+                                        'BaseType' => '273584',
                                         'Name' => 'struct pldm_transport_af_mctp**',
                                         'Size' => '8',
                                         'Type' => 'Pointer'

--- a/include/libpldm/pdr.h
+++ b/include/libpldm/pdr.h
@@ -316,6 +316,16 @@ enum entity_association_containment_type {
 	PLDM_ENTITY_ASSOCIAION_LOGICAL = 0x1,
 };
 
+/** @brief Get the entity using its record handle
+ *
+ *  @param[in] repo - opaque pointer acting as a PDR repo handle
+ *  @param[in] record_handle - record handle of input PDR record
+ *
+ *  @return pldm entity 
+ */
+pldm_entity pldm_get_entity_from_record_handle(const pldm_pdr *repo,
+					       uint32_t record_handle);
+
 /** @struct pldm_entity_association_tree
  *  opaque structure that represents the entity association hierarchy
  */

--- a/src/dsp/pdr.c
+++ b/src/dsp/pdr.c
@@ -462,6 +462,69 @@ void pldm_delete_by_record_handle(pldm_pdr *repo, uint32_t record_handle,
 	}
 }
 
+LIBPLDM_ABI_STABLE
+pldm_entity pldm_get_entity_from_record_handle(const pldm_pdr *repo,
+					       uint32_t record_handle)
+{
+	assert(repo != NULL);
+	pldm_entity element = { 0, 0, 0 };
+
+	pldm_pdr_record *record = repo->first;
+
+	while (record != NULL) {
+		struct pldm_pdr_hdr *hdr = (struct pldm_pdr_hdr *)record->data;
+		if (hdr->record_handle == record_handle) {
+			switch (hdr->type) {
+			case (PLDM_PDR_FRU_RECORD_SET): {
+				struct pldm_pdr_fru_record_set *pdr =
+					(struct pldm_pdr_fru_record_set
+						 *)((uint8_t *)record->data +
+						    sizeof(struct pldm_pdr_hdr));
+				element.entity_type = pdr->entity_type;
+				element.entity_instance_num =
+					pdr->entity_instance;
+				element.entity_container_id = pdr->container_id;
+				return element;
+			}
+			case (PLDM_STATE_SENSOR_PDR): {
+				struct pldm_state_sensor_pdr *pdr =
+					(struct pldm_state_sensor_pdr
+						 *)((uint8_t *)record->data);
+				element.entity_type = pdr->entity_type;
+				element.entity_instance_num =
+					pdr->entity_instance;
+				element.entity_container_id = pdr->container_id;
+				return element;
+			}
+			case (PLDM_STATE_EFFECTER_PDR): {
+				struct pldm_state_effecter_pdr *pdr =
+					(struct pldm_state_effecter_pdr
+						 *)((uint8_t *)record->data);
+				element.entity_type = pdr->entity_type;
+				element.entity_instance_num =
+					pdr->entity_instance;
+				element.entity_container_id = pdr->container_id;
+				return element;
+			}
+			case (PLDM_NUMERIC_EFFECTER_PDR): {
+				struct pldm_numeric_effecter_value_pdr *pdr =
+					(struct pldm_numeric_effecter_value_pdr
+						 *)((uint8_t *)record->data);
+				element.entity_type = pdr->entity_type;
+				element.entity_instance_num =
+					pdr->entity_instance;
+				element.entity_container_id = pdr->container_id;
+				return element;
+			}
+			default:
+				break;
+			}
+		}
+		record = record->next;
+	}
+	return element;
+}
+
 static bool pldm_record_handle_in_range(uint32_t record_handle,
 					uint32_t first_record_handle,
 					uint32_t last_record_handle)

--- a/tests/dsp/pdr.cpp
+++ b/tests/dsp/pdr.cpp
@@ -565,6 +565,77 @@ TEST(PDRAccess, testFindByType)
     pldm_pdr_destroy(repo);
 }
 
+TEST(PDRAccess, getPLDMEntityfromPDR)
+{
+    auto repo = pldm_pdr_init();
+
+    // Test FRU Record set PDR
+    uint32_t handle = 0;
+    int rc = pldm_pdr_add_fru_record_set_check(repo, 1, 10, 1, 0, 100, &handle);
+
+    ASSERT_EQ(rc, 0);
+    auto entity = pldm_get_entity_from_record_handle(repo, handle);
+    EXPECT_EQ(entity.entity_type, htole16(1));
+    EXPECT_EQ(entity.entity_instance_num, htole16(0));
+    EXPECT_EQ(entity.entity_container_id, htole16(100));
+
+    // Test State Effecter PDR
+    std::array<uint8_t, 29> data{212, 1, 0,   0, 1,  11, 0, 0, 19, 0,
+                                 1,   0, 196, 0, 64, 0,  1, 0, 2,  0,
+                                 0,   0, 0,   0, 1,  10, 0, 1, 6};
+    handle = 0;
+    rc = pldm_pdr_add_check(repo, data.data(), data.size(), false, 1, &handle);
+    ASSERT_EQ(rc, 0);
+    entity = pldm_get_entity_from_record_handle(repo, handle);
+    EXPECT_EQ(entity.entity_type, htole16(64));
+    EXPECT_EQ(entity.entity_instance_num, htole16(1));
+    EXPECT_EQ(entity.entity_container_id, htole16(2));
+
+    // Test State Sensor PDR
+    std::array<uint8_t, 27> data2{10, 1, 0, 0,   1, 4,   0, 0, 17,
+                                  0,  1, 0, 199, 0, 120, 0, 4, 0,
+                                  5,  0, 0, 0,   1, 10,  0, 1, 6};
+    handle = 0;
+    rc =
+        pldm_pdr_add_check(repo, data2.data(), data2.size(), false, 1, &handle);
+    ASSERT_EQ(rc, 0);
+    entity = pldm_get_entity_from_record_handle(repo, handle);
+    EXPECT_EQ(entity.entity_type, htole16(120));
+    EXPECT_EQ(entity.entity_instance_num, htole16(4));
+    EXPECT_EQ(entity.entity_container_id, htole16(5));
+
+    // Test Numeric Effecter PDR
+    std::array<uint8_t, 27> data3{10, 1, 0, 0, 1, 9, 0, 0, 17, 0,  1, 0, 199, 0,
+                                  6,  0, 3, 0, 2, 0, 0, 0, 1,  10, 0, 1, 6};
+    handle = 0;
+    rc =
+        pldm_pdr_add_check(repo, data3.data(), data3.size(), false, 1, &handle);
+    ASSERT_EQ(rc, 0);
+    entity = pldm_get_entity_from_record_handle(repo, handle);
+    EXPECT_EQ(entity.entity_type, htole16(6));
+    EXPECT_EQ(entity.entity_instance_num, htole16(3));
+    EXPECT_EQ(entity.entity_container_id, htole16(2));
+
+    // Test Non Supported PDR types
+    std::array<uint8_t, 18> notSupportedtypes{
+        1, 2, 3, 5, 6, 7, 8, 10, 12, 13, 14, 15, 16, 17, 18, 19, 126, 127};
+    for (const auto& type : notSupportedtypes)
+    {
+        std::array<uint8_t, sizeof(pldm_pdr_hdr)> data4{};
+        pldm_pdr_hdr* hdr = reinterpret_cast<pldm_pdr_hdr*>(data4.data());
+        hdr->type = type;
+        handle = 0;
+        rc = pldm_pdr_add_check(repo, data4.data(), data4.size(), false, 1,
+                                &handle);
+        ASSERT_EQ(rc, 0);
+        entity = pldm_get_entity_from_record_handle(repo, handle);
+        EXPECT_EQ(entity.entity_type, htole16(0));
+        EXPECT_EQ(entity.entity_instance_num, htole16(0));
+        EXPECT_EQ(entity.entity_container_id, htole16(0));
+    }
+    pldm_pdr_destroy(repo);
+}
+
 TEST(PDRUpdate, testAddFruRecordSet)
 {
     auto repo = pldm_pdr_init();


### PR DESCRIPTION
After receiving RECORDS DELETED event from Host,
PLDM needs to update the Dbus properties "Availability", "Operation Status". Entity is the key to find the object path for the corresponding PDR. So adding a function to get the entity details using record handle.