### PR TITLE
Fix remove contained entity API

### DIFF
--- a/src/dsp/pdr.c
+++ b/src/dsp/pdr.c
@@ -2209,9 +2209,6 @@ static int pldm_entity_association_find_record_hndl_by_entity(
 	if (!repo || !entity) {
 		return -EINVAL;
 	}
-	uint16_t entity_type = 0;
-	uint16_t entity_instance_num = 0;
-	uint16_t entity_container_id = 0;
 	uint8_t num_children = 0;
 	uint8_t hdr_type = 0;
 	int rc = 0;
@@ -2240,6 +2237,9 @@ static int pldm_entity_association_find_record_hndl_by_entity(
 			}
 			pldm_msgbuf_extract(dst, num_children);
 			for (int i = 0; i < num_children; ++i) {
+				uint16_t entity_type = 0;
+				uint16_t entity_instance_num = 0;
+				uint16_t entity_container_id = 0;
 				pldm_msgbuf_extract(dst, entity_type);
 				pldm_msgbuf_extract(dst, entity_instance_num);
 				pldm_msgbuf_extract(dst, entity_container_id);
@@ -2342,7 +2342,7 @@ int pldm_entity_association_pdr_remove_contained_entity(
 	pldm_msgbuf_copy(dst, src, uint16_t, entity_type);
 	pldm_msgbuf_copy(dst, src, uint16_t, entity_instance_num);
 	pldm_msgbuf_copy(dst, src, uint16_t, entity_container_id);
-	// extract value of number of children from record and increment it
+	// extract value of number of children from record and decrement it
 	// by 1 before insert the value to new record.
 	rc = pldm_msgbuf_extract(src, num_children);
 	if (rc) {
@@ -2359,20 +2359,20 @@ int pldm_entity_association_pdr_remove_contained_entity(
 	}
 	num_children -= 1;
 	pldm_msgbuf_insert(dst, num_children);
-	//Add all children of original PDR to new PDR
-	for (int i = 0; i < num_children - 1; i++) {
+	//Add all children of original PDR to new PDR except the
+	//removed entity one
+	for (int i = 0; i < num_children + 1; ++i) {
 		pldm_msgbuf_extract(src, entity_type);
 		pldm_msgbuf_extract(src, entity_instance_num);
 		pldm_msgbuf_extract(src, entity_container_id);
-		if (entity_type != entity->entity_type &&
-		    entity_instance_num != entity->entity_instance_num &&
-		    entity_container_id != entity->entity_container_id) {
-			pldm_msgbuf_copy(dst, src, uint16_t, child_entity_type);
-			pldm_msgbuf_copy(dst, src, uint16_t,
-					 child_entity_instance_num);
-			pldm_msgbuf_copy(dst, src, uint16_t,
-					 child_entity_container_id);
+		if (entity_type == entity->entity_type &&
+		    entity_instance_num == entity->entity_instance_num &&
+		    entity_container_id == entity->entity_container_id) {
+			continue;
 		}
+		pldm_msgbuf_insert(dst, entity_type);
+		pldm_msgbuf_insert(dst, entity_instance_num);
+		pldm_msgbuf_insert(dst, entity_container_id);
 	}
 	rc = pldm_msgbuf_destroy(src);
 	if (rc) {

--- a/tests/dsp/pdr.cpp
+++ b/tests/dsp/pdr.cpp
@@ -1,6 +1,7 @@
 #include <endian.h>
 #include <libpldm/pdr.h>
 #include <libpldm/platform.h>
+#include <msgbuf.h>
 
 #include <array>
 #include <cstdint>
@@ -417,13 +418,6 @@ TEST(PDRAccess, testGetNext)
 
     pldm_pdr_destroy(repo);
 }
-
-uint32_t record_handle;
-uint32_t size;
-uint8_t* data;
-struct pldm_pdr_record* next;
-bool is_remote;
-uint16_t terminus_handle;
 
 TEST(FindContainerID, testValidInstanceID)
 {
@@ -2190,12 +2184,20 @@ TEST(EntityAssociationPDR, testAddContainedEntityNew)
 
 TEST(EntityAssociationPDR, testRemoveContainedEntity)
 {
-    pldm_entity* entities = (pldm_entity*)malloc(sizeof(pldm_entity) * 3);
+    pldm_entity* entities = (pldm_entity*)malloc(sizeof(pldm_entity) * 4);
     entities[0].entity_type = 1;
+
     entities[1].entity_type = 2;
-    entities[2].entity_type = 3;
-    entities[1].entity_container_id = 2;
     entities[1].entity_instance_num = 1;
+    entities[1].entity_container_id = 2;
+
+    entities[2].entity_type = 3;
+    entities[2].entity_instance_num = 1;
+    entities[2].entity_container_id = 2;
+
+    entities[3].entity_type = 4;
+    entities[3].entity_instance_num = 1;
+    entities[3].entity_container_id = 2;
 
     auto tree = pldm_entity_association_tree_init();
     auto l1 = pldm_entity_association_tree_add_entity(
@@ -2211,20 +2213,81 @@ TEST(EntityAssociationPDR, testRemoveContainedEntity)
         tree, &entities[2], 0xffff, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false,
         true, 0xffff);
     EXPECT_NE(l3, nullptr);
+    auto l4 = pldm_entity_association_tree_add_entity(
+        tree, &entities[3], 0xffff, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL, false,
+        true, 0xffff);
+    EXPECT_NE(l4, nullptr);
 
     EXPECT_EQ(pldm_entity_get_num_children(l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL),
-              2);
+              3);
 
     auto repo = pldm_pdr_init();
 
     EXPECT_EQ(pldm_entity_association_pdr_add_from_node_with_record_handle(
-                  l1, repo, &entities, 3, false, 1, 3),
+                  l1, repo, &entities, 4, false, 1, 3),
               0);
 
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 1u);
 
     uint32_t removed_record_handle{};
     pldm_entity entity{};
+    entity.entity_type = 4;
+    entity.entity_instance_num = 1;
+    entity.entity_container_id = 2;
+
+    EXPECT_EQ(pldm_entity_association_pdr_remove_contained_entity(
+                  repo, &entity, false, &removed_record_handle),
+              0);
+    EXPECT_EQ(removed_record_handle, 3);
+
+    pldm_entity_association_tree_delete_node(tree, entity);
+
+    EXPECT_EQ(pldm_entity_get_num_children(l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL),
+              2);
+
+    uint32_t currRecHandle{};
+    uint32_t nextRecHandle{};
+    uint8_t* data = nullptr;
+    uint32_t size{};
+    pldm_pdr_find_record(repo, currRecHandle, &data, &size, &nextRecHandle);
+    struct pldm_msgbuf _buf;
+    struct pldm_msgbuf* buf = &_buf;
+
+    auto rc =
+        pldm_msgbuf_init_errno(buf,
+                               (sizeof(struct pldm_pdr_hdr) +
+                                sizeof(struct pldm_pdr_entity_association)),
+                               data, size);
+    ASSERT_EQ(rc, 0);
+
+    uint8_t* skip_data = NULL;
+    size_t skip_data_size = sizeof(struct pldm_pdr_hdr) + sizeof(uint16_t) +
+                            sizeof(uint8_t) + sizeof(struct pldm_entity) +
+                            sizeof(uint8_t);
+
+    pldm_msgbuf_span_required(buf, skip_data_size, (void**)&skip_data);
+
+    uint16_t child_data;
+
+    // check pldm_entity data for first child after remove
+    pldm_msgbuf_extract_uint16(buf, &child_data);
+    EXPECT_EQ(child_data, 2);
+    pldm_msgbuf_extract_uint16(buf, &child_data);
+    EXPECT_EQ(child_data, 1);
+    pldm_msgbuf_extract_uint16(buf, &child_data);
+    EXPECT_EQ(child_data, 2);
+
+    // check pldm_entity data for second child after remove
+    pldm_msgbuf_extract_uint16(buf, &child_data);
+    EXPECT_EQ(child_data, 3);
+    pldm_msgbuf_extract_uint16(buf, &child_data);
+    EXPECT_EQ(child_data, 1);
+    pldm_msgbuf_extract_uint16(buf, &child_data);
+    EXPECT_EQ(child_data, 2);
+
+    pldm_msgbuf_destroy(buf);
+
+    removed_record_handle = 0;
     entity.entity_type = 2;
     entity.entity_instance_num = 1;
     entity.entity_container_id = 2;
@@ -2233,6 +2296,11 @@ TEST(EntityAssociationPDR, testRemoveContainedEntity)
                   repo, &entity, false, &removed_record_handle),
               0);
     EXPECT_EQ(removed_record_handle, 3);
+
+    pldm_entity_association_tree_delete_node(tree, entity);
+
+    EXPECT_EQ(pldm_entity_get_num_children(l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL),
+              1);
 
     free(entities);
     pldm_pdr_destroy(repo);


### PR DESCRIPTION
Fix the API remove contained entity so the child entities that are not removed have corrected values of entity_type, entity_instance_num and container_id.