### PR TITLE
oem-ibm: Add Topology State set and enum actions

### DIFF
--- a/include/libpldm/oem/ibm/state_set.h
+++ b/include/libpldm/oem/ibm/state_set.h
@@ -19,6 +19,7 @@ enum ibm_oem_pldm_state_set_ids {
 	PLDM_OEM_IBM_PANEL_TRIGGER_STATE = 32778,
 	PLDM_OEM_IBM_PCIE_SLOT_EFFECTER_STATE = 32779,
 	PLDM_OEM_IBM_PCIE_SLOT_SENSOR_STATE = 32780,
+	PLDM_OEM_IBM_PCIE_TOPOLOGY_ACTIONS = 32781,
 };
 
 enum pldm_oem_ibm_pcie_slot_effecter_state {
@@ -75,6 +76,11 @@ enum ibm_oem_pldm_state_set_boot_side_rename_state_values {
 	PLDM_BOOT_SIDE_HAS_BEEN_RENAMED = 2,
 };
 
+enum pldm_oem_pcie_topology_actions {
+	GET_PCIE_TOPOLOGY = 0x1,
+	GET_CABLE_INFO = 0x2,
+	SAVE_PCIE_TOPLOGY = 0x3,
+};
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The commits adds the state set for the topology actions along with the enumerations for the topology actions.


Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>