### PR TITLE
states: Adding availability state enum

### DIFF
--- a/include/libpldm/states.h
+++ b/include/libpldm/states.h
@@ -21,6 +21,12 @@ enum pldm_system_power_states {
 	PLDM_OFF_SOFT_GRACEFUL = 9,
 };
 
+/** @brief PLDM enums for availability states
+ */
+enum pldm_availability_states {
+	PLDM_RESETTING = 9,
+};
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This commit adds an enum for pldm availability states.