### PR TITLE
pdr: Handle removal of the last contained entity from EA PDR

### DIFF
--- a/src/dsp/pdr.c
+++ b/src/dsp/pdr.c
@@ -2316,8 +2316,9 @@ int pldm_entity_association_pdr_remove_contained_entity(
 	new_record->is_remote = record->is_remote;
 	// Initialize new PDR record with data from original PDR record.
 	// Start with adding the header of original PDR
-	rc = pldm_msgbuf_init_errno(dst, PDR_ENTITY_ASSOCIATION_MIN_SIZE,
-				    new_record->data, new_record->size);
+	rc = pldm_msgbuf_init_errno(
+		dst, (PDR_ENTITY_ASSOCIATION_MIN_SIZE - sizeof(pldm_entity)),
+		new_record->data, new_record->size);
 	if (rc) {
 		goto cleanup_new_record_data;
 	}
@@ -2349,9 +2350,9 @@ int pldm_entity_association_pdr_remove_contained_entity(
 		goto cleanup_new_record_data;
 	}
 	if (num_children == 1) {
-		prev->next = record->next;
-		free(record->data);
-		free(record);
+		// This is the last child which is getting removed so we need to delete the Entity Association PDR.
+		pldm_delete_by_record_handle(repo, record->record_handle,
+					     record->is_remote);
 		goto cleanup_new_record_data;
 	} else if (num_children < 1) {
 		rc = -EOVERFLOW;

--- a/tests/dsp/pdr.cpp
+++ b/tests/dsp/pdr.cpp
@@ -2302,6 +2302,21 @@ TEST(EntityAssociationPDR, testRemoveContainedEntity)
     EXPECT_EQ(pldm_entity_get_num_children(l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL),
               1);
 
+    removed_record_handle = 0;
+    entity.entity_type = 3;
+    entity.entity_instance_num = 1;
+    entity.entity_container_id = 2;
+
+    EXPECT_EQ(pldm_entity_association_pdr_remove_contained_entity(
+                  repo, &entity, false, &removed_record_handle),
+              0);
+    EXPECT_EQ(removed_record_handle, 3);
+
+    pldm_entity_association_tree_delete_node(tree, entity);
+
+    EXPECT_EQ(pldm_entity_get_num_children(l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL),
+              0);
+    EXPECT_EQ(pldm_pdr_get_record_count(repo), 0u);
     free(entities);
     pldm_pdr_destroy(repo);
     pldm_entity_association_tree_destroy(tree);


### PR DESCRIPTION
After removing the contained entity from the enitity association PDR, if there is no other container entity present, we need to remove the entity association PDR.

Tested:
Updated the existing testcase.