### PR TITLE
Updated method to get next container id

### DIFF
--- a/include/libpldm/pdr.h
+++ b/include/libpldm/pdr.h
@@ -388,6 +388,14 @@ typedef struct pldm_entity_node pldm_entity_node;
  */
 pldm_entity_association_tree *pldm_entity_association_tree_init(void);
 
+/** @brief Next Container ID from the association tree
+ *
+ *  @param[in] tree - opaque pointer acting as a handle to the tree
+ *
+ *  @return next container id - container id of the entity
+ */
+uint16_t next_container_id(pldm_entity_association_tree *tree);
+
 /** @brief Add a local entity into the entity association tree
  *
  *  @param[in/out] tree - opaque pointer acting as a handle to the tree

--- a/src/dsp/pdr.c
+++ b/src/dsp/pdr.c
@@ -660,7 +660,8 @@ typedef struct pldm_entity_node {
 	uint8_t association_type;
 } pldm_entity_node;
 
-static inline uint16_t next_container_id(pldm_entity_association_tree *tree)
+LIBPLDM_ABI_STABLE
+uint16_t next_container_id(pldm_entity_association_tree *tree)
 {
 	assert(tree != NULL);
 	assert(tree->last_used_container_id != UINT16_MAX);


### PR DESCRIPTION
PLDM wanted to get the container id from the tree while building the fru (after CM).
Corresponding PLDM commit is
https://github.com/ibm-openbmc/pldm/pull/649