### PR TITLE
create detect-secrets baseline file

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,96 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2025-03-25T13:20:59Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "include/libpldm/bios.h": [
+      {
+        "hashed_secret": "f0c4f28a69ba1d054c0059b18753d195e0eea1e3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 75,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.62.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ Change categories:
 - pdr: Indicates success or failure depending on the outcome of the entity
   association PDR creation
 
+- Register allocation changed for the following APIs:
+
+  - `encode_get_downstream_firmware_parameters_req()`
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Change categories:
 
 - PLDM FD responder accepts a PLDM control handle and will register its version.
 
+- base: Define the minimum request bytes for SetTID command.
+
 ### Changed
 
 - dsp: firmware_update: Expand "params" in symbol names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ Change categories:
   No new error values will be returned, but existing error values may be
   returned under new conditions.
 
+- pdr: Indicates success or failure depending on the outcome of the entity
+  association PDR creation
+
 ### Deprecated
 
 ### Removed
@@ -64,6 +67,7 @@ Change categories:
 
 - pdr: Remove PDR if the contained entity to be removed is the last one
 - meson: sizes.h: add includedir to install path
+- pdr: Create entity association PDRs with unique record handle
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Change categories:
 - meson: sizes.h: add includedir to install path
 - pdr: Create entity association PDRs with unique record handle
 - requester: add null check for instance db object in pldm_instance_id_alloc()
+- requester: add null check for instance db object in pldm_instance_id_free()
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Change categories:
 
 - pdr: Add pldm_pdr_delete_by_record_handle() API
 
+- Support for building the documentation with doxygen
+
 ### Changed
 
 - dsp: firmware_update: Expand "params" in symbol names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Change categories:
 
 - base: Define the minimum request bytes for SetTID command.
 
+- pdr: Add pldm_pdr_delete_by_record_handle() API
+
 ### Changed
 
 - dsp: firmware_update: Expand "params" in symbol names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Change categories:
 - pdr: Remove PDR if the contained entity to be removed is the last one
 - meson: sizes.h: add includedir to install path
 - pdr: Create entity association PDRs with unique record handle
+- requester: add null check for instance db object in pldm_instance_id_alloc()
 
 ### Security
 

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1,0 +1,360 @@
+# Doxyfile 1.9.8
+
+#---------------------------------------------------------------------------
+# Project related configuration options
+#---------------------------------------------------------------------------
+DOXYFILE_ENCODING      = UTF-8
+PROJECT_NAME           = @project@
+PROJECT_NUMBER         = @version@
+PROJECT_BRIEF          = @description@
+PROJECT_LOGO           =
+OUTPUT_DIRECTORY       =
+CREATE_SUBDIRS         = NO
+CREATE_SUBDIRS_LEVEL   = 8
+ALLOW_UNICODE_NAMES    = NO
+OUTPUT_LANGUAGE        = English
+BRIEF_MEMBER_DESC      = YES
+REPEAT_BRIEF           = YES
+ABBREVIATE_BRIEF       = "The $name class" \
+                         "The $name widget" \
+                         "The $name file" \
+                         is \
+                         provides \
+                         specifies \
+                         contains \
+                         represents \
+                         a \
+                         an \
+                         the
+ALWAYS_DETAILED_SEC    = NO
+INLINE_INHERITED_MEMB  = NO
+FULL_PATH_NAMES        = YES
+STRIP_FROM_PATH        =
+STRIP_FROM_INC_PATH    =
+SHORT_NAMES            = NO
+JAVADOC_AUTOBRIEF      = NO
+JAVADOC_BANNER         = NO
+QT_AUTOBRIEF           = NO
+MULTILINE_CPP_IS_BRIEF = NO
+PYTHON_DOCSTRING       = YES
+INHERIT_DOCS           = YES
+SEPARATE_MEMBER_PAGES  = NO
+TAB_SIZE               = 4
+ALIASES                =
+OPTIMIZE_OUTPUT_FOR_C  = YES
+OPTIMIZE_OUTPUT_JAVA   = NO
+OPTIMIZE_FOR_FORTRAN   = NO
+OPTIMIZE_OUTPUT_VHDL   = NO
+OPTIMIZE_OUTPUT_SLICE  = NO
+EXTENSION_MAPPING      =
+MARKDOWN_SUPPORT       = YES
+TOC_INCLUDE_HEADINGS   = 5
+MARKDOWN_ID_STYLE      = DOXYGEN
+AUTOLINK_SUPPORT       = YES
+BUILTIN_STL_SUPPORT    = NO
+CPP_CLI_SUPPORT        = NO
+SIP_SUPPORT            = NO
+IDL_PROPERTY_SUPPORT   = YES
+DISTRIBUTE_GROUP_DOC   = NO
+GROUP_NESTED_COMPOUNDS = NO
+SUBGROUPING            = YES
+INLINE_GROUPED_CLASSES = NO
+INLINE_SIMPLE_STRUCTS  = NO
+TYPEDEF_HIDES_STRUCT   = NO
+LOOKUP_CACHE_SIZE      = 0
+NUM_PROC_THREADS       = 0
+TIMESTAMP              = NO
+#---------------------------------------------------------------------------
+# Build related configuration options
+#---------------------------------------------------------------------------
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = NO
+EXTRACT_PRIV_VIRTUAL   = NO
+EXTRACT_PACKAGE        = NO
+EXTRACT_STATIC         = NO
+EXTRACT_LOCAL_CLASSES  = NO
+EXTRACT_LOCAL_METHODS  = NO
+EXTRACT_ANON_NSPACES   = NO
+RESOLVE_UNNAMED_PARAMS = YES
+HIDE_UNDOC_MEMBERS     = NO
+HIDE_UNDOC_CLASSES     = NO
+HIDE_FRIEND_COMPOUNDS  = NO
+HIDE_IN_BODY_DOCS      = NO
+INTERNAL_DOCS          = NO
+CASE_SENSE_NAMES       = SYSTEM
+HIDE_SCOPE_NAMES       = NO
+HIDE_COMPOUND_REFERENCE= NO
+SHOW_HEADERFILE        = YES
+SHOW_INCLUDE_FILES     = YES
+SHOW_GROUPED_MEMB_INC  = NO
+FORCE_LOCAL_INCLUDES   = NO
+INLINE_INFO            = YES
+SORT_MEMBER_DOCS       = NO
+SORT_BRIEF_DOCS        = NO
+SORT_MEMBERS_CTORS_1ST = NO
+SORT_GROUP_NAMES       = NO
+SORT_BY_SCOPE_NAME     = NO
+STRICT_PROTO_MATCHING  = YES
+GENERATE_TODOLIST      = YES
+GENERATE_TESTLIST      = YES
+GENERATE_BUGLIST       = YES
+GENERATE_DEPRECATEDLIST= YES
+ENABLED_SECTIONS       =
+MAX_INITIALIZER_LINES  = 30
+SHOW_USED_FILES        = YES
+SHOW_FILES             = YES
+SHOW_NAMESPACES        = YES
+FILE_VERSION_FILTER    =
+LAYOUT_FILE            =
+CITE_BIB_FILES         =
+#---------------------------------------------------------------------------
+# Configuration options related to warning and progress messages
+#---------------------------------------------------------------------------
+QUIET                  = NO
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_DOC_ERROR      = YES
+WARN_IF_INCOMPLETE_DOC = YES
+WARN_NO_PARAMDOC       = YES
+WARN_IF_UNDOC_ENUM_VAL = NO
+WARN_AS_ERROR          = NO
+WARN_FORMAT            = "$file:$line: $text"
+WARN_LINE_FORMAT       = "at line $line of file $file"
+WARN_LOGFILE           =
+#---------------------------------------------------------------------------
+# Configuration options related to the input files
+#---------------------------------------------------------------------------
+INPUT                  = @sources@
+INPUT_ENCODING         = UTF-8
+INPUT_FILE_ENCODING    =
+FILE_PATTERNS          =
+RECURSIVE              = YES
+EXCLUDE                =
+EXCLUDE_SYMLINKS       = NO
+EXCLUDE_PATTERNS       =
+EXCLUDE_SYMBOLS        =
+EXAMPLE_PATH           =
+EXAMPLE_PATTERNS       = *
+EXAMPLE_RECURSIVE      = NO
+IMAGE_PATH             =
+INPUT_FILTER           =
+FILTER_PATTERNS        =
+FILTER_SOURCE_FILES    = NO
+FILTER_SOURCE_PATTERNS =
+USE_MDFILE_AS_MAINPAGE =
+FORTRAN_COMMENT_AFTER  = 72
+#---------------------------------------------------------------------------
+# Configuration options related to source browsing
+#---------------------------------------------------------------------------
+SOURCE_BROWSER         = NO
+INLINE_SOURCES         = NO
+STRIP_CODE_COMMENTS    = YES
+REFERENCED_BY_RELATION = NO
+REFERENCES_RELATION    = NO
+REFERENCES_LINK_SOURCE = YES
+SOURCE_TOOLTIPS        = YES
+USE_HTAGS              = NO
+VERBATIM_HEADERS       = YES
+CLANG_ASSISTED_PARSING = NO
+CLANG_ADD_INC_PATHS    = YES
+CLANG_OPTIONS          =
+CLANG_DATABASE_PATH    =
+#---------------------------------------------------------------------------
+# Configuration options related to the alphabetical class index
+#---------------------------------------------------------------------------
+ALPHABETICAL_INDEX     = YES
+IGNORE_PREFIX          =
+#---------------------------------------------------------------------------
+# Configuration options related to the HTML output
+#---------------------------------------------------------------------------
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+HTML_FILE_EXTENSION    = .html
+HTML_HEADER            =
+HTML_FOOTER            =
+HTML_STYLESHEET        =
+HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_FILES       =
+HTML_COLORSTYLE        = AUTO_LIGHT
+HTML_COLORSTYLE_HUE    = 220
+HTML_COLORSTYLE_SAT    = 100
+HTML_COLORSTYLE_GAMMA  = 80
+HTML_DYNAMIC_MENUS     = YES
+HTML_DYNAMIC_SECTIONS  = NO
+HTML_CODE_FOLDING      = YES
+HTML_INDEX_NUM_ENTRIES = 100
+GENERATE_DOCSET        = NO
+DOCSET_FEEDNAME        = "Doxygen generated docs"
+DOCSET_FEEDURL         =
+DOCSET_BUNDLE_ID       = org.openbmc.libpldm
+DOCSET_PUBLISHER_ID    = org.openbmc
+DOCSET_PUBLISHER_NAME  = OpenBMC
+GENERATE_HTMLHELP      = NO
+CHM_FILE               =
+HHC_LOCATION           =
+GENERATE_CHI           = NO
+CHM_INDEX_ENCODING     =
+BINARY_TOC             = NO
+TOC_EXPAND             = NO
+SITEMAP_URL            =
+GENERATE_QHP           = NO
+QCH_FILE               =
+QHP_NAMESPACE          = org.openbmc.libldm
+QHP_VIRTUAL_FOLDER     = doc
+QHP_CUST_FILTER_NAME   =
+QHP_CUST_FILTER_ATTRS  =
+QHP_SECT_FILTER_ATTRS  =
+QHG_LOCATION           =
+GENERATE_ECLIPSEHELP   = NO
+ECLIPSE_DOC_ID         = org.openbmc.libpldm
+DISABLE_INDEX          = NO
+GENERATE_TREEVIEW      = NO
+FULL_SIDEBAR           = NO
+ENUM_VALUES_PER_LINE   = 4
+TREEVIEW_WIDTH         = 250
+EXT_LINKS_IN_WINDOW    = NO
+OBFUSCATE_EMAILS       = YES
+HTML_FORMULA_FORMAT    = png
+FORMULA_FONTSIZE       = 10
+FORMULA_MACROFILE      =
+USE_MATHJAX            = NO
+MATHJAX_VERSION        = MathJax_2
+MATHJAX_FORMAT         = HTML-CSS
+MATHJAX_RELPATH        =
+MATHJAX_EXTENSIONS     =
+MATHJAX_CODEFILE       =
+SEARCHENGINE           = YES
+SERVER_BASED_SEARCH    = NO
+EXTERNAL_SEARCH        = NO
+SEARCHENGINE_URL       =
+SEARCHDATA_FILE        = searchdata.xml
+EXTERNAL_SEARCH_ID     =
+EXTRA_SEARCH_MAPPINGS  =
+#---------------------------------------------------------------------------
+# Configuration options related to the LaTeX output
+#---------------------------------------------------------------------------
+GENERATE_LATEX         = NO
+LATEX_OUTPUT           = latex
+LATEX_CMD_NAME         =
+MAKEINDEX_CMD_NAME     = makeindex
+LATEX_MAKEINDEX_CMD    = makeindex
+COMPACT_LATEX          = NO
+PAPER_TYPE             = a4
+EXTRA_PACKAGES         =
+LATEX_HEADER           =
+LATEX_FOOTER           =
+LATEX_EXTRA_STYLESHEET =
+LATEX_EXTRA_FILES      =
+PDF_HYPERLINKS         = YES
+USE_PDFLATEX           = YES
+LATEX_BATCHMODE        = NO
+LATEX_HIDE_INDICES     = NO
+LATEX_BIB_STYLE        = plain
+LATEX_EMOJI_DIRECTORY  =
+#---------------------------------------------------------------------------
+# Configuration options related to the RTF output
+#---------------------------------------------------------------------------
+GENERATE_RTF           = NO
+RTF_OUTPUT             = rtf
+COMPACT_RTF            = NO
+RTF_HYPERLINKS         = NO
+RTF_STYLESHEET_FILE    =
+RTF_EXTENSIONS_FILE    =
+#---------------------------------------------------------------------------
+# Configuration options related to the man page output
+#---------------------------------------------------------------------------
+GENERATE_MAN           = NO
+MAN_OUTPUT             = man
+MAN_EXTENSION          = .3
+MAN_SUBDIR             =
+MAN_LINKS              = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the XML output
+#---------------------------------------------------------------------------
+GENERATE_XML           = NO
+XML_OUTPUT             = xml
+XML_PROGRAMLISTING     = YES
+XML_NS_MEMB_FILE_SCOPE = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the DOCBOOK output
+#---------------------------------------------------------------------------
+GENERATE_DOCBOOK       = NO
+DOCBOOK_OUTPUT         = docbook
+#---------------------------------------------------------------------------
+# Configuration options for the AutoGen Definitions output
+#---------------------------------------------------------------------------
+GENERATE_AUTOGEN_DEF   = NO
+#---------------------------------------------------------------------------
+# Configuration options related to Sqlite3 output
+#---------------------------------------------------------------------------
+GENERATE_SQLITE3       = NO
+SQLITE3_OUTPUT         = sqlite3
+SQLITE3_RECREATE_DB    = YES
+#---------------------------------------------------------------------------
+# Configuration options related to the Perl module output
+#---------------------------------------------------------------------------
+GENERATE_PERLMOD       = NO
+PERLMOD_LATEX          = NO
+PERLMOD_PRETTY         = YES
+PERLMOD_MAKEVAR_PREFIX =
+#---------------------------------------------------------------------------
+# Configuration options related to the preprocessor
+#---------------------------------------------------------------------------
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = NO
+EXPAND_ONLY_PREDEF     = NO
+SEARCH_INCLUDES        = YES
+INCLUDE_PATH           =
+INCLUDE_FILE_PATTERNS  =
+PREDEFINED             =
+EXPAND_AS_DEFINED      =
+SKIP_FUNCTION_MACROS   = YES
+#---------------------------------------------------------------------------
+# Configuration options related to external references
+#---------------------------------------------------------------------------
+TAGFILES               =
+GENERATE_TAGFILE       =
+ALLEXTERNALS           = NO
+EXTERNAL_GROUPS        = YES
+EXTERNAL_PAGES         = YES
+#---------------------------------------------------------------------------
+# Configuration options related to diagram generator tools
+#---------------------------------------------------------------------------
+HIDE_UNDOC_RELATIONS   = YES
+HAVE_DOT               = YES
+DOT_NUM_THREADS        = 0
+DOT_COMMON_ATTR        = "fontname=Helvetica,fontsize=10"
+DOT_EDGE_ATTR          = "labelfontname=Helvetica,labelfontsize=10"
+DOT_NODE_ATTR          = "shape=box,height=0.2,width=0.4"
+DOT_FONTPATH           =
+CLASS_GRAPH            = YES
+COLLABORATION_GRAPH    = YES
+GROUP_GRAPHS           = YES
+UML_LOOK               = NO
+UML_LIMIT_NUM_FIELDS   = 10
+DOT_UML_DETAILS        = NO
+DOT_WRAP_THRESHOLD     = 17
+TEMPLATE_RELATIONS     = NO
+INCLUDE_GRAPH          = YES
+INCLUDED_BY_GRAPH      = YES
+CALL_GRAPH             = NO
+CALLER_GRAPH           = NO
+GRAPHICAL_HIERARCHY    = YES
+DIRECTORY_GRAPH        = YES
+DIR_GRAPH_MAX_DEPTH    = 1
+DOT_IMAGE_FORMAT       = png
+INTERACTIVE_SVG        = NO
+DOT_PATH               =
+DOTFILE_DIRS           =
+DIA_PATH               =
+DIAFILE_DIRS           =
+PLANTUML_JAR_PATH      =
+PLANTUML_CFG_FILE      =
+PLANTUML_INCLUDE_PATH  =
+DOT_GRAPH_MAX_NODES    = 50
+MAX_DOT_GRAPH_DEPTH    = 0
+DOT_MULTI_TARGETS      = NO
+GENERATE_LEGEND        = YES
+DOT_CLEANUP            = YES
+MSCGEN_TOOL            =
+MSCFILE_DIRS           =

--- a/abi/x86_64/gcc.dump
+++ b/abi/x86_64/gcc.dump
@@ -37,327 +37,77 @@ $VAR1 = {
     'pdr.c' => 1
   },
   'SymbolInfo' => {
-    '1298' => {
-      'Header' => 'utils.h',
-      'Line' => '108',
-      'Param' => {
-        '0' => {
-          'name' => 'transfer_flag',
-          'type' => '121'
-        }
-      },
-      'Return' => '805',
-      'ShortName' => 'is_transfer_flag_valid'
-    },
-    '1358' => {
-      'Header' => 'utils.h',
-      'Line' => '99',
-      'Param' => {
-        '0' => {
-          'name' => 'seconds',
-          'type' => '121'
-        },
-        '1' => {
-          'name' => 'minutes',
-          'type' => '121'
-        },
-        '2' => {
-          'name' => 'hours',
-          'type' => '121'
-        },
-        '3' => {
-          'name' => 'day',
-          'type' => '121'
-        },
-        '4' => {
-          'name' => 'month',
-          'type' => '121'
-        },
-        '5' => {
-          'name' => 'year',
-          'type' => '1006'
-        }
-      },
-      'Return' => '805',
-      'ShortName' => 'is_time_legal'
-    },
-    '1602' => {
-      'Header' => 'utils.h',
-      'Line' => '87',
-      'Param' => {
-        '0' => {
-          'name' => 'dec',
-          'type' => '1018'
-        }
-      },
-      'Return' => '1018',
-      'ShortName' => 'dec2bcd32'
-    },
-    '1731' => {
-      'Header' => 'utils.h',
-      'Line' => '81',
-      'Param' => {
-        '0' => {
-          'name' => 'bcd',
-          'type' => '1018'
-        }
-      },
-      'Return' => '1018',
-      'ShortName' => 'bcd2dec32'
-    },
-    '1834' => {
-      'Header' => 'utils.h',
-      'Line' => '75',
-      'Param' => {
-        '0' => {
-          'name' => 'dec',
-          'type' => '1006'
-        }
-      },
-      'Return' => '1006',
-      'ShortName' => 'dec2bcd16'
-    },
-    '1950' => {
-      'Header' => 'utils.h',
-      'Line' => '69',
-      'Param' => {
-        '0' => {
-          'name' => 'bcd',
-          'type' => '1006'
-        }
-      },
-      'Return' => '1006',
-      'ShortName' => 'bcd2dec16'
-    },
-    '2053' => {
-      'Header' => 'utils.h',
-      'Line' => '63',
-      'Param' => {
-        '0' => {
-          'name' => 'dec',
-          'type' => '121'
-        }
-      },
-      'Return' => '121',
-      'ShortName' => 'dec2bcd8'
-    },
-    '2106' => {
-      'Header' => 'utils.h',
-      'Line' => '57',
-      'Param' => {
-        '0' => {
-          'name' => 'bcd',
-          'type' => '121'
-        }
-      },
-      'Return' => '121',
-      'ShortName' => 'bcd2dec8'
-    },
-    '2159' => {
-      'Header' => 'utils.h',
-      'Line' => '51',
-      'Param' => {
-        '0' => {
-          'name' => 'version',
-          'type' => '2283'
-        },
-        '1' => {
-          'name' => 'buffer',
-          'type' => '977'
-        },
-        '2' => {
-          'name' => 'buffer_size',
-          'type' => '1140'
-        }
-      },
-      'Reg' => {
-        '0' => 'rdi',
-        '1' => 'rcx'
-      },
-      'Return' => '1202',
-      'ShortName' => 'ver2str'
-    },
-    '2288' => {
-      'Header' => 'utils.h',
-      'Line' => '31',
-      'Param' => {
-        '0' => {
-          'name' => 'data',
-          'type' => '2396'
-        },
-        '1' => {
-          'name' => 'size',
-          'type' => '1140'
-        }
-      },
-      'Reg' => {
-        '1' => 'rdx'
-      },
-      'Return' => '121',
-      'ShortName' => 'crc8'
-    },
-    '2402' => {
-      'Header' => 'utils.h',
-      'Line' => '39',
-      'Param' => {
-        '0' => {
-          'name' => 'data',
-          'type' => '2396'
-        },
-        '1' => {
-          'name' => 'size',
-          'type' => '1140'
-        }
-      },
-      'Reg' => {
-        '1' => 'rcx'
-      },
-      'Return' => '1018',
-      'ShortName' => 'crc32'
-    },
-    '4037' => {
+    '1401' => {
       'Header' => 'base.h',
-      'Line' => '655',
-      'Param' => {
-        '0' => {
-          'name' => 'msg_type',
-          'type' => '121'
-        },
-        '1' => {
-          'name' => 'instance_id',
-          'type' => '121'
-        },
-        '2' => {
-          'name' => 'pldm_type',
-          'type' => '121'
-        },
-        '3' => {
-          'name' => 'command',
-          'type' => '121'
-        },
-        '4' => {
-          'name' => 'msg',
-          'type' => '4270'
-        }
-      },
-      'Return' => '100',
-      'ShortName' => 'encode_pldm_header_only'
-    },
-    '4469' => {
-      'Header' => 'base.h',
-      'Line' => '642',
+      'Line' => '644',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'type',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'command',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'cc',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_cc_only_resp'
     },
-    '4680' => {
+    '1448' => {
       'Header' => 'base.h',
-      'Line' => '625',
-      'Param' => {
-        '0' => {
-          'name' => 'msg',
-          'type' => '4914'
-        },
-        '1' => {
-          'name' => 'payload_length',
-          'type' => '1140'
-        },
-        '2' => {
-          'name' => 'pldm_type',
-          'type' => '4919'
-        },
-        '3' => {
-          'name' => 'transfer_opflag',
-          'type' => '4919'
-        },
-        '4' => {
-          'name' => 'transfer_ctx',
-          'type' => '4924'
-        },
-        '5' => {
-          'name' => 'transfer_handle',
-          'type' => '4924'
-        },
-        '6' => {
-          'name' => 'section_offset',
-          'offset' => '0',
-          'type' => '4924'
-        },
-        '7' => {
-          'name' => 'section_length',
-          'offset' => '8',
-          'type' => '4924'
-        }
-      },
-      'Reg' => {
-        '2' => 'rdx',
-        '3' => 'r10',
-        '4' => 'r8',
-        '5' => 'r9'
-      },
-      'Return' => '100',
-      'ShortName' => 'decode_multipart_receive_req'
-    },
-    '4934' => {
-      'Header' => 'base.h',
-      'Line' => '607',
+      'Line' => '536',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
-          'name' => 'tid',
-          'type' => '121'
+          'name' => 'completion_code',
+          'type' => '135'
         },
         '2' => {
+          'name' => 'commands',
+          'type' => '1268'
+        },
+        '3' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
-      'ShortName' => 'encode_set_tid_req'
+      'ShortName' => 'encode_get_commands_resp'
     },
-    '5131' => {
+    '1485' => {
       'Header' => 'base.h',
-      'Line' => '489',
+      'Line' => '522',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
-          'name' => 'completion_code',
-          'type' => '4919'
+          'name' => 'type',
+          'type' => '1186'
         },
         '3' => {
-          'name' => 'tid',
-          'type' => '4919'
+          'name' => 'version',
+          'type' => '1527'
         }
       },
       'Reg' => {
@@ -367,110 +117,95 @@ $VAR1 = {
         '3' => 'rcx'
       },
       'Return' => '100',
-      'ShortName' => 'decode_get_tid_resp'
+      'ShortName' => 'decode_get_commands_req'
     },
-    '5248' => {
+    '1532' => {
       'Header' => 'base.h',
-      'Line' => '595',
+      'Line' => '509',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
-          'name' => 'tid',
-          'type' => '121'
+          'name' => 'types',
+          'type' => '1268'
         },
         '3' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
-      'ShortName' => 'encode_get_tid_resp'
+      'ShortName' => 'encode_get_types_resp'
     },
-    '5460' => {
+    '1569' => {
       'Header' => 'base.h',
-      'Line' => '583',
+      'Line' => '555',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
-          'name' => 'msg',
-          'type' => '4270'
-        }
-      },
-      'Return' => '100',
-      'ShortName' => 'encode_get_tid_req'
-    },
-    '5594' => {
-      'Header' => 'base.h',
-      'Line' => '468',
-      'Param' => {
-        '0' => {
-          'name' => 'msg',
-          'type' => '4914'
-        },
-        '1' => {
-          'name' => 'payload_length',
-          'type' => '1140'
+          'name' => 'completion_code',
+          'type' => '135'
         },
         '2' => {
-          'name' => 'completion_code',
-          'type' => '4919'
-        },
-        '3' => {
           'name' => 'next_transfer_handle',
-          'type' => '4924'
+          'type' => '147'
+        },
+        '3' => {
+          'name' => 'transfer_flag',
+          'type' => '135'
         },
         '4' => {
-          'name' => 'transfer_flag',
-          'type' => '4919'
+          'name' => 'version_data',
+          'type' => '1621'
         },
         '5' => {
-          'name' => 'version',
-          'type' => '5824'
+          'name' => 'version_size',
+          'type' => '164'
+        },
+        '6' => {
+          'name' => 'msg',
+          'offset' => '0',
+          'type' => '1443'
         }
       },
       'Reg' => {
-        '1' => 'r10',
-        '2' => 'rdx',
-        '3' => 'rcx',
-        '4' => 'r8',
-        '5' => 'r9'
+        '2' => 'r15'
       },
       'Return' => '100',
-      'ShortName' => 'decode_get_version_resp'
+      'ShortName' => 'encode_get_version_resp'
     },
-    '5834' => {
+    '1626' => {
       'Header' => 'base.h',
-      'Line' => '567',
+      'Line' => '569',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'transfer_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '3' => {
           'name' => 'transfer_opflag',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'type',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -483,93 +218,452 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_version_req'
     },
-    '5965' => {
+    '1673' => {
       'Header' => 'base.h',
-      'Line' => '553',
+      'Line' => '597',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
-          'name' => 'next_transfer_handle',
-          'type' => '1018'
+          'name' => 'tid',
+          'type' => '135'
         },
         '3' => {
+          'name' => 'msg',
+          'type' => '1443'
+        }
+      },
+      'Return' => '100',
+      'ShortName' => 'encode_get_tid_resp'
+    },
+    '1710' => {
+      'Header' => 'base.h',
+      'Line' => '367',
+      'Param' => {
+        '0' => {
+          'name' => 'msg',
+          'type' => '1737'
+        },
+        '1' => {
+          'name' => 'hdr',
+          'type' => '1742'
+        }
+      },
+      'Return' => '135',
+      'ShortName' => 'unpack_pldm_header'
+    },
+    '5952' => {
+      'Header' => 'utils.h',
+      'Line' => '108',
+      'Param' => {
+        '0' => {
           'name' => 'transfer_flag',
-          'type' => '121'
+          'type' => '135'
+        }
+      },
+      'Return' => '5459',
+      'ShortName' => 'is_transfer_flag_valid'
+    },
+    '6012' => {
+      'Header' => 'utils.h',
+      'Line' => '99',
+      'Param' => {
+        '0' => {
+          'name' => 'seconds',
+          'type' => '135'
+        },
+        '1' => {
+          'name' => 'minutes',
+          'type' => '135'
+        },
+        '2' => {
+          'name' => 'hours',
+          'type' => '135'
+        },
+        '3' => {
+          'name' => 'day',
+          'type' => '135'
         },
         '4' => {
-          'name' => 'version_data',
-          'type' => '2283'
+          'name' => 'month',
+          'type' => '135'
         },
         '5' => {
-          'name' => 'version_size',
-          'type' => '1140'
+          'name' => 'year',
+          'type' => '5660'
+        }
+      },
+      'Return' => '5459',
+      'ShortName' => 'is_time_legal'
+    },
+    '6256' => {
+      'Header' => 'utils.h',
+      'Line' => '87',
+      'Param' => {
+        '0' => {
+          'name' => 'dec',
+          'type' => '147'
+        }
+      },
+      'Return' => '147',
+      'ShortName' => 'dec2bcd32'
+    },
+    '6385' => {
+      'Header' => 'utils.h',
+      'Line' => '81',
+      'Param' => {
+        '0' => {
+          'name' => 'bcd',
+          'type' => '147'
+        }
+      },
+      'Return' => '147',
+      'ShortName' => 'bcd2dec32'
+    },
+    '6488' => {
+      'Header' => 'utils.h',
+      'Line' => '75',
+      'Param' => {
+        '0' => {
+          'name' => 'dec',
+          'type' => '5660'
+        }
+      },
+      'Return' => '5660',
+      'ShortName' => 'dec2bcd16'
+    },
+    '6604' => {
+      'Header' => 'utils.h',
+      'Line' => '69',
+      'Param' => {
+        '0' => {
+          'name' => 'bcd',
+          'type' => '5660'
+        }
+      },
+      'Return' => '5660',
+      'ShortName' => 'bcd2dec16'
+    },
+    '6707' => {
+      'Header' => 'utils.h',
+      'Line' => '63',
+      'Param' => {
+        '0' => {
+          'name' => 'dec',
+          'type' => '135'
+        }
+      },
+      'Return' => '135',
+      'ShortName' => 'dec2bcd8'
+    },
+    '6760' => {
+      'Header' => 'utils.h',
+      'Line' => '57',
+      'Param' => {
+        '0' => {
+          'name' => 'bcd',
+          'type' => '135'
+        }
+      },
+      'Return' => '135',
+      'ShortName' => 'bcd2dec8'
+    },
+    '6813' => {
+      'Header' => 'utils.h',
+      'Line' => '51',
+      'Param' => {
+        '0' => {
+          'name' => 'version',
+          'type' => '1621'
         },
-        '6' => {
-          'name' => 'msg',
-          'offset' => '0',
-          'type' => '4270'
+        '1' => {
+          'name' => 'buffer',
+          'type' => '5631'
+        },
+        '2' => {
+          'name' => 'buffer_size',
+          'type' => '164'
         }
       },
       'Reg' => {
-        '2' => 'r15'
+        '0' => 'rdi',
+        '1' => 'rcx'
       },
-      'Return' => '100',
-      'ShortName' => 'encode_get_version_resp'
+      'Return' => '5856',
+      'ShortName' => 'ver2str'
     },
-    '6337' => {
-      'Header' => 'base.h',
-      'Line' => '449',
+    '6942' => {
+      'Header' => 'utils.h',
+      'Line' => '31',
       'Param' => {
         '0' => {
-          'name' => 'instance_id',
-          'type' => '121'
+          'name' => 'data',
+          'type' => '1262'
         },
         '1' => {
-          'name' => 'transfer_handle',
-          'type' => '1018'
+          'name' => 'size',
+          'type' => '164'
+        }
+      },
+      'Reg' => {
+        '1' => 'rdx'
+      },
+      'Return' => '135',
+      'ShortName' => 'crc8'
+    },
+    '7056' => {
+      'Header' => 'utils.h',
+      'Line' => '39',
+      'Param' => {
+        '0' => {
+          'name' => 'data',
+          'type' => '1262'
+        },
+        '1' => {
+          'name' => 'size',
+          'type' => '164'
+        }
+      },
+      'Reg' => {
+        '1' => 'rcx'
+      },
+      'Return' => '147',
+      'ShortName' => 'crc32'
+    },
+    '8690' => {
+      'Header' => 'base.h',
+      'Line' => '657',
+      'Param' => {
+        '0' => {
+          'name' => 'msg_type',
+          'type' => '135'
+        },
+        '1' => {
+          'name' => 'instance_id',
+          'type' => '135'
         },
         '2' => {
-          'name' => 'transfer_opflag',
-          'type' => '121'
+          'name' => 'pldm_type',
+          'type' => '135'
         },
         '3' => {
-          'name' => 'type',
-          'type' => '121'
+          'name' => 'command',
+          'type' => '135'
         },
         '4' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
+        }
+      },
+      'Return' => '100',
+      'ShortName' => 'encode_pldm_header_only'
+    },
+    '9333' => {
+      'Header' => 'base.h',
+      'Line' => '627',
+      'Param' => {
+        '0' => {
+          'name' => 'msg',
+          'type' => '1522'
+        },
+        '1' => {
+          'name' => 'payload_length',
+          'type' => '164'
+        },
+        '2' => {
+          'name' => 'pldm_type',
+          'type' => '1186'
+        },
+        '3' => {
+          'name' => 'transfer_opflag',
+          'type' => '1186'
+        },
+        '4' => {
+          'name' => 'transfer_ctx',
+          'type' => '1668'
+        },
+        '5' => {
+          'name' => 'transfer_handle',
+          'type' => '1668'
+        },
+        '6' => {
+          'name' => 'section_offset',
+          'offset' => '0',
+          'type' => '1668'
+        },
+        '7' => {
+          'name' => 'section_length',
+          'offset' => '8',
+          'type' => '1668'
+        }
+      },
+      'Reg' => {
+        '2' => 'rdx',
+        '3' => 'r10',
+        '4' => 'r8',
+        '5' => 'r9'
+      },
+      'Return' => '100',
+      'ShortName' => 'decode_multipart_receive_req'
+    },
+    '9587' => {
+      'Header' => 'base.h',
+      'Line' => '609',
+      'Param' => {
+        '0' => {
+          'name' => 'instance_id',
+          'type' => '135'
+        },
+        '1' => {
+          'name' => 'tid',
+          'type' => '135'
+        },
+        '2' => {
+          'name' => 'msg',
+          'type' => '1443'
+        }
+      },
+      'Return' => '100',
+      'ShortName' => 'encode_set_tid_req'
+    },
+    '9784' => {
+      'Header' => 'base.h',
+      'Line' => '491',
+      'Param' => {
+        '0' => {
+          'name' => 'msg',
+          'type' => '1522'
+        },
+        '1' => {
+          'name' => 'payload_length',
+          'type' => '164'
+        },
+        '2' => {
+          'name' => 'completion_code',
+          'type' => '1186'
+        },
+        '3' => {
+          'name' => 'tid',
+          'type' => '1186'
+        }
+      },
+      'Reg' => {
+        '0' => 'rdi',
+        '1' => 'rsi',
+        '2' => 'rdx',
+        '3' => 'rcx'
+      },
+      'Return' => '100',
+      'ShortName' => 'decode_get_tid_resp'
+    },
+    '10113' => {
+      'Header' => 'base.h',
+      'Line' => '585',
+      'Param' => {
+        '0' => {
+          'name' => 'instance_id',
+          'type' => '135'
+        },
+        '1' => {
+          'name' => 'msg',
+          'type' => '1443'
+        }
+      },
+      'Return' => '100',
+      'ShortName' => 'encode_get_tid_req'
+    },
+    '10247' => {
+      'Header' => 'base.h',
+      'Line' => '470',
+      'Param' => {
+        '0' => {
+          'name' => 'msg',
+          'type' => '1522'
+        },
+        '1' => {
+          'name' => 'payload_length',
+          'type' => '164'
+        },
+        '2' => {
+          'name' => 'completion_code',
+          'type' => '1186'
+        },
+        '3' => {
+          'name' => 'next_transfer_handle',
+          'type' => '1668'
+        },
+        '4' => {
+          'name' => 'transfer_flag',
+          'type' => '1186'
+        },
+        '5' => {
+          'name' => 'version',
+          'type' => '1527'
+        }
+      },
+      'Reg' => {
+        '1' => 'r10',
+        '2' => 'rdx',
+        '3' => 'rcx',
+        '4' => 'r8',
+        '5' => 'r9'
+      },
+      'Return' => '100',
+      'ShortName' => 'decode_get_version_resp'
+    },
+    '10990' => {
+      'Header' => 'base.h',
+      'Line' => '451',
+      'Param' => {
+        '0' => {
+          'name' => 'instance_id',
+          'type' => '135'
+        },
+        '1' => {
+          'name' => 'transfer_handle',
+          'type' => '147'
+        },
+        '2' => {
+          'name' => 'transfer_opflag',
+          'type' => '135'
+        },
+        '3' => {
+          'name' => 'type',
+          'type' => '135'
+        },
+        '4' => {
+          'name' => 'msg',
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_version_req'
     },
-    '6569' => {
+    '11222' => {
       'Header' => 'base.h',
-      'Line' => '430',
+      'Line' => '432',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'commands',
-          'type' => '6753'
+          'type' => '11406'
         }
       },
       'Reg' => {
@@ -581,25 +675,25 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_commands_resp'
     },
-    '6763' => {
+    '11416' => {
       'Header' => 'base.h',
-      'Line' => '397',
+      'Line' => '399',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'types',
-          'type' => '6753'
+          'type' => '11406'
         }
       },
       'Reg' => {
@@ -611,103 +705,25 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_types_resp'
     },
-    '6948' => {
+    '12256' => {
       'Header' => 'base.h',
-      'Line' => '534',
+      'Line' => '414',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
-        },
-        '1' => {
-          'name' => 'completion_code',
-          'type' => '121'
-        },
-        '2' => {
-          'name' => 'commands',
-          'type' => '7217'
-        },
-        '3' => {
-          'name' => 'msg',
-          'type' => '4270'
-        }
-      },
-      'Return' => '100',
-      'ShortName' => 'encode_get_commands_resp'
-    },
-    '7222' => {
-      'Header' => 'base.h',
-      'Line' => '520',
-      'Param' => {
-        '0' => {
-          'name' => 'msg',
-          'type' => '4914'
-        },
-        '1' => {
-          'name' => 'payload_length',
-          'type' => '1140'
-        },
-        '2' => {
-          'name' => 'type',
-          'type' => '4919'
-        },
-        '3' => {
-          'name' => 'version',
-          'type' => '5824'
-        }
-      },
-      'Reg' => {
-        '0' => 'rdi',
-        '1' => 'rsi',
-        '2' => 'rdx',
-        '3' => 'rcx'
-      },
-      'Return' => '100',
-      'ShortName' => 'decode_get_commands_req'
-    },
-    '7334' => {
-      'Header' => 'base.h',
-      'Line' => '507',
-      'Param' => {
-        '0' => {
-          'name' => 'instance_id',
-          'type' => '121'
-        },
-        '1' => {
-          'name' => 'completion_code',
-          'type' => '121'
-        },
-        '2' => {
-          'name' => 'types',
-          'type' => '7217'
-        },
-        '3' => {
-          'name' => 'msg',
-          'type' => '4270'
-        }
-      },
-      'Return' => '100',
-      'ShortName' => 'encode_get_types_resp'
-    },
-    '7603' => {
-      'Header' => 'base.h',
-      'Line' => '412',
-      'Param' => {
-        '0' => {
-          'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'type',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'version',
-          'type' => '1088'
+          'type' => '427'
         },
         '3' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Reg' => {
@@ -716,101 +732,85 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_get_commands_req'
     },
-    '7809' => {
+    '12462' => {
       'Header' => 'base.h',
-      'Line' => '380',
+      'Line' => '382',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_types_req'
     },
-    '7941' => {
+    '12594' => {
       'Header' => 'base.h',
-      'Line' => '235',
+      'Line' => '237',
       'Param' => {
         '0' => {
           'name' => 'req',
-          'type' => '8009'
+          'type' => '1737'
         },
         '1' => {
           'name' => 'resp',
-          'type' => '8009'
+          'type' => '1737'
         }
       },
       'Reg' => {
         '0' => 'rdi',
         '1' => 'rsi'
       },
-      'Return' => '805',
+      'Return' => '5459',
       'ShortName' => 'pldm_msg_hdr_correlate_response'
     },
-    '8014' => {
+    '12928' => {
       'Header' => 'base.h',
-      'Line' => '365',
-      'Param' => {
-        '0' => {
-          'name' => 'msg',
-          'type' => '8009'
-        },
-        '1' => {
-          'name' => 'hdr',
-          'type' => '8249'
-        }
-      },
-      'Return' => '121',
-      'ShortName' => 'unpack_pldm_header'
-    },
-    '8275' => {
-      'Header' => 'base.h',
-      'Line' => '352',
+      'Line' => '354',
       'Param' => {
         '0' => {
           'name' => 'hdr',
-          'type' => '8510'
+          'type' => '3157'
         },
         '1' => {
           'name' => 'msg',
-          'type' => '8515'
+          'type' => '13168'
         }
       },
-      'Return' => '121',
+      'Return' => '135',
       'ShortName' => 'pack_pldm_header'
     },
-    '10604' => {
+    '15257' => {
       'Header' => 'bios.h',
       'Line' => '612',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'transfer_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '3' => {
           'name' => 'transfer_flag',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'table_type',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'table',
-          'type' => '10781'
+          'type' => '15434'
         }
       },
       'Reg' => {
@@ -823,49 +823,49 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_set_bios_table_req'
     },
-    '10791' => {
+    '15444' => {
       'Header' => 'bios.h',
       'Line' => '594',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'next_transfer_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_set_bios_table_resp'
     },
-    '11010' => {
+    '15663' => {
       'Header' => 'bios.h',
       'Line' => '322',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'next_transfer_handle',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Reg' => {
@@ -877,95 +877,95 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_set_bios_table_resp'
     },
-    '11120' => {
+    '15773' => {
       'Header' => 'bios.h',
       'Line' => '302',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'transfer_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '2' => {
           'name' => 'transfer_flag',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'table_type',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'table_data',
-          'type' => '1214'
+          'type' => '5868'
         },
         '5' => {
           'name' => 'table_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '6' => {
           'name' => 'msg',
           'offset' => '0',
-          'type' => '4270'
+          'type' => '1443'
         },
         '7' => {
           'name' => 'payload_length',
           'offset' => '8',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_set_bios_table_req'
     },
-    '11509' => {
+    '16162' => {
       'Header' => 'bios.h',
       'Line' => '514',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'next_transfer_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_set_bios_attribute_current_value_resp'
     },
-    '11723' => {
+    '16376' => {
       'Header' => 'bios.h',
       'Line' => '502',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'transfer_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '3' => {
           'name' => 'transfer_flag',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'attribute',
-          'type' => '10781'
+          'type' => '15434'
         }
       },
       'Reg' => {
@@ -977,25 +977,25 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_set_bios_attribute_current_value_req'
     },
-    '11870' => {
+    '16523' => {
       'Header' => 'bios.h',
       'Line' => '279',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'next_transfer_handle',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Reg' => {
@@ -1007,38 +1007,38 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_set_bios_attribute_current_value_resp'
     },
-    '11980' => {
+    '16633' => {
       'Header' => 'bios.h',
       'Line' => '259',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'transfer_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '2' => {
           'name' => 'transfer_flag',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'attribute_data',
-          'type' => '1214'
+          'type' => '5868'
         },
         '4' => {
           'name' => 'attribute_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '5' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '6' => {
           'name' => 'payload_length',
           'offset' => '0',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
@@ -1047,38 +1047,38 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_set_bios_attribute_current_value_req'
     },
-    '12352' => {
+    '17005' => {
       'Header' => 'bios.h',
       'Line' => '480',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'next_transfer_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'transfer_flag',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'attribute_data',
-          'type' => '1214'
+          'type' => '5868'
         },
         '5' => {
           'name' => 'attribute_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '6' => {
           'name' => 'msg',
           'offset' => '0',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Reg' => {
@@ -1087,29 +1087,29 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_get_bios_current_value_by_handle_resp'
     },
-    '12721' => {
+    '17374' => {
       'Header' => 'bios.h',
       'Line' => '461',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'transfer_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '3' => {
           'name' => 'transfer_op_flag',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'attribute_handle',
-          'type' => '12863'
+          'type' => '17516'
         }
       },
       'Reg' => {
@@ -1121,33 +1121,33 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_bios_attribute_current_value_by_handle_req'
     },
-    '12873' => {
+    '17526' => {
       'Header' => 'bios.h',
       'Line' => '446',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'next_transfer_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'transfer_flag',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'attribute_data',
-          'type' => '10781'
+          'type' => '15434'
         }
       },
       'Reg' => {
@@ -1160,61 +1160,61 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_bios_attribute_current_value_by_handle_resp'
     },
-    '13035' => {
+    '17688' => {
       'Header' => 'bios.h',
       'Line' => '430',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'transfer_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '2' => {
           'name' => 'transfer_op_flag',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'attribute_handle',
-          'type' => '1006'
+          'type' => '5660'
         },
         '4' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_bios_attribute_current_value_by_handle_req'
     },
-    '13264' => {
+    '17917' => {
       'Header' => 'bios.h',
       'Line' => '412',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'next_transfer_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'transfer_flag',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'bios_table_offset',
-          'type' => '13426'
+          'type' => '2697'
         }
       },
       'Reg' => {
@@ -1227,29 +1227,29 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_bios_table_resp'
     },
-    '13436' => {
+    '18089' => {
       'Header' => 'bios.h',
       'Line' => '395',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'transfer_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '3' => {
           'name' => 'transfer_op_flag',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'table_type',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -1261,66 +1261,66 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_bios_table_req'
     },
-    '13583' => {
+    '18236' => {
       'Header' => 'bios.h',
       'Line' => '381',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'transfer_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '2' => {
           'name' => 'transfer_op_flag',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'table_type',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_bios_table_req'
     },
-    '13807' => {
+    '18460' => {
       'Header' => 'bios.h',
       'Line' => '366',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'next_transfer_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'transfer_flag',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'table_data',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '6' => {
           'name' => 'msg',
           'offset' => '0',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Reg' => {
@@ -1329,21 +1329,21 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_get_bios_table_resp'
     },
-    '14160' => {
+    '18813' => {
       'Header' => 'bios.h',
       'Line' => '581',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -1354,67 +1354,67 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_set_date_time_resp'
     },
-    '14233' => {
+    '18886' => {
       'Header' => 'bios.h',
       'Line' => '565',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '3' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_set_date_time_resp'
     },
-    '14440' => {
+    '19093' => {
       'Header' => 'bios.h',
       'Line' => '551',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'seconds',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'minutes',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'hours',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'day',
-          'type' => '4919'
+          'type' => '1186'
         },
         '6' => {
           'name' => 'month',
           'offset' => '0',
-          'type' => '4919'
+          'type' => '1186'
         },
         '7' => {
           'name' => 'year',
           'offset' => '8',
-          'type' => '12863'
+          'type' => '17516'
         }
       },
       'Reg' => {
@@ -1426,95 +1426,95 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_set_date_time_req'
     },
-    '14731' => {
+    '19384' => {
       'Header' => 'bios.h',
       'Line' => '534',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'seconds',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'minutes',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'hours',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'day',
-          'type' => '121'
+          'type' => '135'
         },
         '5' => {
           'name' => 'month',
-          'type' => '121'
+          'type' => '135'
         },
         '6' => {
           'name' => 'year',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '7' => {
           'name' => 'msg',
           'offset' => '8',
-          'type' => '4270'
+          'type' => '1443'
         },
         '8' => {
           'name' => 'payload_length',
           'offset' => '16',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_set_date_time_req'
     },
-    '15224' => {
+    '19877' => {
       'Header' => 'bios.h',
       'Line' => '238',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'seconds',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'minutes',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'hours',
-          'type' => '4919'
+          'type' => '1186'
         },
         '6' => {
           'name' => 'day',
           'offset' => '0',
-          'type' => '4919'
+          'type' => '1186'
         },
         '7' => {
           'name' => 'month',
           'offset' => '8',
-          'type' => '4919'
+          'type' => '1186'
         },
         '8' => {
           'name' => 'year',
           'offset' => '16',
-          'type' => '12863'
+          'type' => '17516'
         }
       },
       'Reg' => {
@@ -1527,116 +1527,116 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_date_time_resp'
     },
-    '15425' => {
+    '20078' => {
       'Header' => 'bios.h',
       'Line' => '346',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'seconds',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'minutes',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'hours',
-          'type' => '121'
+          'type' => '135'
         },
         '5' => {
           'name' => 'day',
-          'type' => '121'
+          'type' => '135'
         },
         '6' => {
           'name' => 'month',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '7' => {
           'name' => 'year',
           'offset' => '8',
-          'type' => '1006'
+          'type' => '5660'
         },
         '8' => {
           'name' => 'msg',
           'offset' => '16',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_date_time_resp'
     },
-    '15709' => {
+    '20362' => {
       'Header' => 'bios.h',
       'Line' => '217',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_date_time_req'
     },
-    '17655' => {
+    '22308' => {
       'Header' => 'bios_table.h',
       'Line' => '633',
       'Param' => {
         '0' => {
           'name' => 'table',
-          'type' => '1214'
+          'type' => '5868'
         },
         '1' => {
           'name' => 'size',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
         '0' => 'rdi',
         '1' => 'rsi'
       },
-      'Return' => '805',
+      'Return' => '5459',
       'ShortName' => 'pldm_bios_table_checksum'
     },
-    '17800' => {
+    '22453' => {
       'Header' => 'bios_table.h',
       'Line' => '624',
       'Param' => {
         '0' => {
           'name' => 'src_table',
-          'type' => '2396'
+          'type' => '1262'
         },
         '1' => {
           'name' => 'src_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'dest_table',
-          'type' => '2634'
+          'type' => '126'
         },
         '3' => {
           'name' => 'dest_length',
-          'type' => '13426'
+          'type' => '2697'
         },
         '4' => {
           'name' => 'entry',
-          'type' => '2396'
+          'type' => '1262'
         },
         '5' => {
           'name' => 'entry_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
@@ -1646,90 +1646,90 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_bios_table_attr_value_copy_and_update'
     },
-    '18488' => {
+    '23141' => {
       'Header' => 'bios_table.h',
       'Line' => '590',
       'Param' => {
         '0' => {
           'name' => 'table',
-          'type' => '2396'
+          'type' => '1262'
         },
         '1' => {
           'name' => 'length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'handle',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Reg' => {
         '2' => 'r8'
       },
-      'Return' => '18483',
+      'Return' => '23136',
       'ShortName' => 'pldm_bios_table_attr_value_find_by_handle'
     },
-    '18751' => {
+    '23404' => {
       'Header' => 'bios_table.h',
       'Line' => '197',
       'Param' => {
         '0' => {
           'name' => 'table',
-          'type' => '2396'
+          'type' => '1262'
         },
         '1' => {
           'name' => 'length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'handle',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Reg' => {
         '2' => 'r8'
       },
-      'Return' => '18897',
+      'Return' => '23550',
       'ShortName' => 'pldm_bios_table_attr_find_by_string_handle'
     },
-    '19018' => {
+    '23671' => {
       'Header' => 'bios_table.h',
       'Line' => '187',
       'Param' => {
         '0' => {
           'name' => 'table',
-          'type' => '2396'
+          'type' => '1262'
         },
         '1' => {
           'name' => 'length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'handle',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Reg' => {
         '2' => 'r8'
       },
-      'Return' => '18897',
+      'Return' => '23550',
       'ShortName' => 'pldm_bios_table_attr_find_by_handle'
     },
-    '19280' => {
+    '23933' => {
       'Header' => 'bios_table.h',
       'Line' => '146',
       'Param' => {
         '0' => {
           'name' => 'table',
-          'type' => '2396'
+          'type' => '1262'
         },
         '1' => {
           'name' => 'length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'str',
-          'type' => '3999'
+          'type' => '8652'
         }
       },
       'Reg' => {
@@ -1737,98 +1737,98 @@ $VAR1 = {
         '1' => 'r12',
         '2' => 'rbx'
       },
-      'Return' => '19500',
+      'Return' => '24153',
       'ShortName' => 'pldm_bios_table_string_find_by_string'
     },
-    '19669' => {
+    '24322' => {
       'Header' => 'bios_table.h',
       'Line' => '155',
       'Param' => {
         '0' => {
           'name' => 'table',
-          'type' => '2396'
+          'type' => '1262'
         },
         '1' => {
           'name' => 'length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'handle',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Reg' => {
         '2' => 'r8'
       },
-      'Return' => '19500',
+      'Return' => '24153',
       'ShortName' => 'pldm_bios_table_string_find_by_handle'
     },
-    '20430' => {
+    '25083' => {
       'Header' => 'bios_table.h',
       'Line' => '53',
       'Param' => {
         '0' => {
           'name' => 'iter',
-          'type' => '18478'
+          'type' => '23131'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '2396',
+      'Return' => '1262',
       'ShortName' => 'pldm_bios_table_iter_value'
     },
-    '20478' => {
+    '25131' => {
       'Header' => 'bios_table.h',
       'Line' => '47',
       'Param' => {
         '0' => {
           'name' => 'iter',
-          'type' => '18478'
+          'type' => '23131'
         }
       },
       'Return' => '1',
       'ShortName' => 'pldm_bios_table_iter_next'
     },
-    '20588' => {
+    '25241' => {
       'Header' => 'bios_table.h',
       'Line' => '42',
       'Param' => {
         '0' => {
           'name' => 'iter',
-          'type' => '20663'
+          'type' => '25316'
         }
       },
-      'Return' => '805',
+      'Return' => '5459',
       'ShortName' => 'pldm_bios_table_iter_is_end'
     },
-    '20668' => {
+    '25321' => {
       'Header' => 'bios_table.h',
       'Line' => '34',
       'Param' => {
         '0' => {
           'name' => 'iter',
-          'type' => '18478'
+          'type' => '23131'
         }
       },
       'Return' => '1',
       'ShortName' => 'pldm_bios_table_iter_free'
     },
-    '20740' => {
+    '25393' => {
       'Header' => 'bios_table.h',
       'Line' => '28',
       'Param' => {
         '0' => {
           'name' => 'table',
-          'type' => '2396'
+          'type' => '1262'
         },
         '1' => {
           'name' => 'length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'type',
-          'type' => '16354'
+          'type' => '21007'
         }
       },
       'Reg' => {
@@ -1836,24 +1836,24 @@ $VAR1 = {
         '1' => 'r12',
         '2' => 'rbx'
       },
-      'Return' => '18478',
+      'Return' => '23131',
       'ShortName' => 'pldm_bios_table_iter_create'
     },
-    '20978' => {
+    '25631' => {
       'Header' => 'bios_table.h',
       'Line' => '609',
       'Param' => {
         '0' => {
           'name' => 'table',
-          'type' => '2634'
+          'type' => '126'
         },
         '1' => {
           'name' => 'capacity',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'size',
-          'type' => '13426'
+          'type' => '2697'
         }
       },
       'Reg' => {
@@ -1864,83 +1864,83 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_bios_table_append_pad_checksum'
     },
-    '21278' => {
+    '25931' => {
       'Header' => 'bios_table.h',
       'Line' => '597',
       'Param' => {
         '0' => {
           'name' => 'size_without_pad',
-          'type' => '1140'
+          'type' => '164'
         }
       },
-      'Return' => '1140',
+      'Return' => '164',
       'ShortName' => 'pldm_bios_table_pad_checksum_size'
     },
-    '21613' => {
+    '26266' => {
       'Header' => 'bios_table.h',
       'Line' => '572',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18483'
+          'type' => '23136'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '1006',
+      'Return' => '5660',
       'ShortName' => 'pldm_bios_table_attr_value_entry_decode_handle'
     },
-    '21662' => {
+    '26315' => {
       'Header' => 'bios_table.h',
       'Line' => '579',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18483'
+          'type' => '23136'
         }
       },
-      'Return' => '1140',
+      'Return' => '164',
       'ShortName' => 'pldm_bios_table_attr_value_entry_length'
     },
-    '22146' => {
+    '26799' => {
       'Header' => 'bios_table.h',
       'Line' => '546',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18483'
+          'type' => '23136'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '16196',
+      'Return' => '20849',
       'ShortName' => 'pldm_bios_table_attr_value_entry_integer_decode_cv'
     },
-    '22286' => {
+    '26939' => {
       'Header' => 'bios_table.h',
       'Line' => '562',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '2634'
+          'type' => '126'
         },
         '1' => {
           'name' => 'entry_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'attr_handle',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'attr_type',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'cv',
-          'type' => '16196'
+          'type' => '20849'
         }
       },
       'Reg' => {
@@ -1953,39 +1953,39 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_bios_table_attr_value_entry_encode_integer'
     },
-    '22555' => {
+    '27208' => {
       'Header' => 'bios_table.h',
       'Line' => '540',
-      'Return' => '1140',
+      'Return' => '164',
       'ShortName' => 'pldm_bios_table_attr_value_entry_encode_integer_length'
     },
-    '22717' => {
+    '27370' => {
       'Header' => 'bios_table.h',
       'Line' => '533',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '2634'
+          'type' => '126'
         },
         '1' => {
           'name' => 'entry_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'attr_handle',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'attr_type',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'str_length',
-          'type' => '1006'
+          'type' => '5660'
         },
         '5' => {
           'name' => 'str',
-          'type' => '3999'
+          'type' => '8652'
         }
       },
       'Reg' => {
@@ -1999,79 +1999,79 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_bios_table_attr_value_entry_encode_string'
     },
-    '23079' => {
+    '27732' => {
       'Header' => 'bios_table.h',
       'Line' => '514',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18483'
+          'type' => '23136'
         },
         '1' => {
           'name' => 'current_string',
-          'type' => '10781'
+          'type' => '15434'
         }
       },
       'Return' => '1',
       'ShortName' => 'pldm_bios_table_attr_value_entry_string_decode_string'
     },
-    '23174' => {
+    '27827' => {
       'Header' => 'bios_table.h',
       'Line' => '504',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18483'
+          'type' => '23136'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '1006',
+      'Return' => '5660',
       'ShortName' => 'pldm_bios_table_attr_value_entry_string_decode_length'
     },
-    '23315' => {
+    '27968' => {
       'Header' => 'bios_table.h',
       'Line' => '498',
       'Param' => {
         '0' => {
           'name' => 'string_length',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '1140',
+      'Return' => '164',
       'ShortName' => 'pldm_bios_table_attr_value_entry_encode_string_length'
     },
-    '23497' => {
+    '28150' => {
       'Header' => 'bios_table.h',
       'Line' => '488',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '2634'
+          'type' => '126'
         },
         '1' => {
           'name' => 'entry_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'attr_handle',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'attr_type',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'count',
-          'type' => '121'
+          'type' => '135'
         },
         '5' => {
           'name' => 'handles',
-          'type' => '1214'
+          'type' => '5868'
         }
       },
       'Reg' => {
@@ -2084,109 +2084,109 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_bios_table_attr_value_entry_encode_enum'
     },
-    '23784' => {
+    '28437' => {
       'Header' => 'bios_table.h',
       'Line' => '469',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18483'
+          'type' => '23136'
         },
         '1' => {
           'name' => 'handles',
-          'type' => '4919'
+          'type' => '1186'
         },
         '2' => {
           'name' => 'number',
-          'type' => '121'
+          'type' => '135'
         }
       },
-      'Return' => '121',
+      'Return' => '135',
       'ShortName' => 'pldm_bios_table_attr_value_entry_enum_decode_handles'
     },
-    '24031' => {
+    '28684' => {
       'Header' => 'bios_table.h',
       'Line' => '459',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18483'
+          'type' => '23136'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '121',
+      'Return' => '135',
       'ShortName' => 'pldm_bios_table_attr_value_entry_enum_decode_number'
     },
-    '24080' => {
+    '28733' => {
       'Header' => 'bios_table.h',
       'Line' => '453',
       'Param' => {
         '0' => {
           'name' => 'count',
-          'type' => '121'
+          'type' => '135'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '1140',
+      'Return' => '164',
       'ShortName' => 'pldm_bios_table_attr_value_entry_encode_enum_length'
     },
-    '24129' => {
+    '28782' => {
       'Header' => 'bios_table.h',
       'Line' => '446',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18483'
+          'type' => '23136'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '121',
+      'Return' => '135',
       'ShortName' => 'pldm_bios_table_attr_value_entry_decode_attribute_type'
     },
-    '24178' => {
+    '28831' => {
       'Header' => 'bios_table.h',
       'Line' => '439',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18483'
+          'type' => '23136'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '1006',
+      'Return' => '5660',
       'ShortName' => 'pldm_bios_table_attr_value_entry_decode_attribute_handle'
     },
-    '24725' => {
+    '29378' => {
       'Header' => 'bios_table.h',
       'Line' => '431',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18897'
+          'type' => '23550'
         },
         '1' => {
           'name' => 'lower',
-          'type' => '24846'
+          'type' => '29499'
         },
         '2' => {
           'name' => 'upper',
-          'type' => '24846'
+          'type' => '29499'
         },
         '3' => {
           'name' => 'scalar',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'def',
-          'type' => '24846'
+          'type' => '29499'
         }
       },
       'Reg' => {
@@ -2199,21 +2199,21 @@ $VAR1 = {
       'Return' => '1',
       'ShortName' => 'pldm_bios_table_attr_entry_integer_decode'
     },
-    '24861' => {
+    '29514' => {
       'Header' => 'bios_table.h',
       'Line' => '419',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '2634'
+          'type' => '126'
         },
         '1' => {
           'name' => 'entry_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'info',
-          'type' => '25123'
+          'type' => '29776'
         }
       },
       'Reg' => {
@@ -2224,107 +2224,107 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_bios_table_attr_entry_integer_encode'
     },
-    '25133' => {
+    '29786' => {
       'Header' => 'bios_table.h',
       'Line' => '400',
       'Param' => {
         '0' => {
           'name' => 'info',
-          'type' => '25123'
+          'type' => '29776'
         },
         '1' => {
           'name' => 'errmsg',
-          'type' => '25432'
+          'type' => '30085'
         }
       },
       'Return' => '100',
       'ShortName' => 'pldm_bios_table_attr_entry_integer_info_check'
     },
-    '25437' => {
+    '30090' => {
       'Header' => 'bios_table.h',
       'Line' => '407',
-      'Return' => '1140',
+      'Return' => '164',
       'ShortName' => 'pldm_bios_table_attr_entry_integer_encode_length'
     },
-    '25613' => {
+    '30266' => {
       'Header' => 'bios_table.h',
       'Line' => '374',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18897'
+          'type' => '23550'
         },
         '1' => {
           'name' => 'buffer',
-          'type' => '977'
+          'type' => '5631'
         },
         '2' => {
           'name' => 'size',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
         '2' => 'r12'
       },
-      'Return' => '1006',
+      'Return' => '5660',
       'ShortName' => 'pldm_bios_table_attr_entry_string_decode_def_string'
     },
-    '25907' => {
+    '30560' => {
       'Header' => 'bios_table.h',
       'Line' => '366',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18897'
+          'type' => '23550'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '1006',
+      'Return' => '5660',
       'ShortName' => 'pldm_bios_table_attr_entry_string_decode_min_length'
     },
-    '25976' => {
+    '30629' => {
       'Header' => 'bios_table.h',
       'Line' => '358',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18897'
+          'type' => '23550'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '1006',
+      'Return' => '5660',
       'ShortName' => 'pldm_bios_table_attr_entry_string_decode_max_length'
     },
-    '26045' => {
+    '30698' => {
       'Header' => 'bios_table.h',
       'Line' => '350',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18897'
+          'type' => '23550'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '121',
+      'Return' => '135',
       'ShortName' => 'pldm_bios_table_attr_entry_string_decode_string_type'
     },
-    '26114' => {
+    '30767' => {
       'Header' => 'bios_table.h',
       'Line' => '342',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18897'
+          'type' => '23550'
         },
         '1' => {
           'name' => 'def_string_length',
-          'type' => '12863'
+          'type' => '17516'
         }
       },
       'Reg' => {
@@ -2334,21 +2334,21 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_bios_table_attr_entry_string_decode_def_string_length'
     },
-    '26202' => {
+    '30855' => {
       'Header' => 'bios_table.h',
       'Line' => '331',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '2634'
+          'type' => '126'
         },
         '1' => {
           'name' => 'entry_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'info',
-          'type' => '26561'
+          'type' => '31214'
         }
       },
       'Reg' => {
@@ -2358,17 +2358,17 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_bios_table_attr_entry_string_encode'
     },
-    '26566' => {
+    '31219' => {
       'Header' => 'bios_table.h',
       'Line' => '310',
       'Param' => {
         '0' => {
           'name' => 'info',
-          'type' => '26561'
+          'type' => '31214'
         },
         '1' => {
           'name' => 'errmsg',
-          'type' => '25432'
+          'type' => '30085'
         }
       },
       'Reg' => {
@@ -2377,60 +2377,60 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_bios_table_attr_entry_string_info_check'
     },
-    '26835' => {
+    '31488' => {
       'Header' => 'bios_table.h',
       'Line' => '318',
       'Param' => {
         '0' => {
           'name' => 'def_str_len',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '1140',
+      'Return' => '164',
       'ShortName' => 'pldm_bios_table_attr_entry_string_encode_length'
     },
-    '27085' => {
+    '31738' => {
       'Header' => 'bios_table.h',
       'Line' => '284',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18897'
+          'type' => '23550'
         },
         '1' => {
           'name' => 'def_indices',
-          'type' => '4919'
+          'type' => '1186'
         },
         '2' => {
           'name' => 'def_num',
-          'type' => '121'
+          'type' => '135'
         }
       },
       'Reg' => {
         '0' => 'rbp',
         '1' => 'r12'
       },
-      'Return' => '121',
+      'Return' => '135',
       'ShortName' => 'pldm_bios_table_attr_entry_enum_decode_def_indices'
     },
-    '27382' => {
+    '32035' => {
       'Header' => 'bios_table.h',
       'Line' => '272',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18897'
+          'type' => '23550'
         },
         '1' => {
           'name' => 'pv_hdls',
-          'type' => '12863'
+          'type' => '17516'
         },
         '2' => {
           'name' => 'pv_num',
-          'type' => '121'
+          'type' => '135'
         }
       },
       'Reg' => {
@@ -2441,17 +2441,17 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_bios_table_attr_entry_enum_decode_pv_hdls'
     },
-    '27547' => {
+    '32200' => {
       'Header' => 'bios_table.h',
       'Line' => '255',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18897'
+          'type' => '23550'
         },
         '1' => {
           'name' => 'def_num',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -2461,17 +2461,17 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_bios_table_attr_entry_enum_decode_def_num'
     },
-    '27626' => {
+    '32279' => {
       'Header' => 'bios_table.h',
       'Line' => '245',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18897'
+          'type' => '23550'
         },
         '1' => {
           'name' => 'pv_num',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -2481,21 +2481,21 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_bios_table_attr_entry_enum_decode_pv_num'
     },
-    '27686' => {
+    '32339' => {
       'Header' => 'bios_table.h',
       'Line' => '234',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '2634'
+          'type' => '126'
         },
         '1' => {
           'name' => 'entry_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'info',
-          'type' => '28015'
+          'type' => '32668'
         }
       },
       'Reg' => {
@@ -2505,86 +2505,86 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_bios_table_attr_entry_enum_encode'
     },
-    '28020' => {
+    '32673' => {
       'Header' => 'bios_table.h',
       'Line' => '220',
       'Param' => {
         '0' => {
           'name' => 'pv_num',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'def_num',
-          'type' => '121'
+          'type' => '135'
         }
       },
       'Reg' => {
         '0' => 'rdi',
         '1' => 'rsi'
       },
-      'Return' => '1140',
+      'Return' => '164',
       'ShortName' => 'pldm_bios_table_attr_entry_enum_encode_length'
     },
-    '28080' => {
+    '32733' => {
       'Header' => 'bios_table.h',
       'Line' => '177',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18897'
+          'type' => '23550'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '1006',
+      'Return' => '5660',
       'ShortName' => 'pldm_bios_table_attr_entry_decode_string_handle'
     },
-    '28127' => {
+    '32780' => {
       'Header' => 'bios_table.h',
       'Line' => '169',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18897'
+          'type' => '23550'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '121',
+      'Return' => '135',
       'ShortName' => 'pldm_bios_table_attr_entry_decode_attribute_type'
     },
-    '28174' => {
+    '32827' => {
       'Header' => 'bios_table.h',
       'Line' => '162',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '18897'
+          'type' => '23550'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '1006',
+      'Return' => '5660',
       'ShortName' => 'pldm_bios_table_attr_entry_decode_attribute_handle'
     },
-    '28807' => {
+    '33460' => {
       'Header' => 'bios_table.h',
       'Line' => '135',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '19500'
+          'type' => '24153'
         },
         '1' => {
           'name' => 'buffer',
-          'type' => '977'
+          'type' => '5631'
         },
         '2' => {
           'name' => 'size',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
@@ -2595,98 +2595,98 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_bios_table_string_entry_decode_string'
     },
-    '29044' => {
+    '33697' => {
       'Header' => 'bios_table.h',
       'Line' => '120',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '19500'
+          'type' => '24153'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '1006',
+      'Return' => '5660',
       'ShortName' => 'pldm_bios_table_string_entry_decode_string_length'
     },
-    '29091' => {
+    '33744' => {
       'Header' => 'bios_table.h',
       'Line' => '113',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '19500'
+          'type' => '24153'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '1006',
+      'Return' => '5660',
       'ShortName' => 'pldm_bios_table_string_entry_decode_handle'
     },
-    '29138' => {
+    '33791' => {
       'Header' => 'bios_table.h',
       'Line' => '106',
       'Param' => {
         '0' => {
           'name' => 'entry',
-          'type' => '2634'
+          'type' => '126'
         },
         '1' => {
           'name' => 'entry_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'str',
-          'type' => '3999'
+          'type' => '8652'
         },
         '3' => {
           'name' => 'str_length',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Return' => '100',
       'ShortName' => 'pldm_bios_table_string_entry_encode'
     },
-    '29495' => {
+    '34148' => {
       'Header' => 'bios_table.h',
       'Line' => '92',
       'Param' => {
         '0' => {
           'name' => 'string_length',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '1140',
+      'Return' => '164',
       'ShortName' => 'pldm_bios_table_string_entry_encode_length'
     },
-    '36345' => {
+    '42541' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1703',
+      'Line' => '2039',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'non_functioning_component_indication',
-          'type' => '36527'
+          'type' => '42723'
         },
         '4' => {
           'name' => 'non_functioning_component_bitmap',
-          'type' => '36532'
+          'type' => '42728'
         }
       },
       'Reg' => {
@@ -2697,41 +2697,41 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_cancel_update_resp'
     },
-    '36542' => {
+    '42738' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1686',
+      'Line' => '2022',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '2' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_cancel_update_req'
     },
-    '36713' => {
+    '42909' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1671',
+      'Line' => '2007',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -2742,73 +2742,73 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_cancel_update_component_resp'
     },
-    '36789' => {
+    '42985' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1659',
+      'Line' => '1995',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '2' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_cancel_update_component_req'
     },
-    '36960' => {
+    '44645' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1641',
+      'Line' => '1962',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'current_state',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'previous_state',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'aux_state',
-          'type' => '4919'
+          'type' => '1186'
         },
         '6' => {
           'name' => 'aux_state_status',
           'offset' => '0',
-          'type' => '4919'
+          'type' => '1186'
         },
         '7' => {
           'name' => 'progress_percent',
           'offset' => '8',
-          'type' => '4919'
+          'type' => '1186'
         },
         '8' => {
           'name' => 'reason_code',
           'offset' => '16',
-          'type' => '4919'
+          'type' => '1186'
         },
         '9' => {
           'name' => 'update_option_flags_enabled',
           'offset' => '24',
-          'type' => '37287'
+          'type' => '44972'
         }
       },
       'Reg' => {
@@ -2820,45 +2820,45 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_status_resp'
     },
-    '37297' => {
+    '44982' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1621',
+      'Line' => '1942',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '2' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_status_req'
     },
-    '37468' => {
+    '45874' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1605',
+      'Line' => '1910',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'estimated_time_activation',
-          'type' => '12863'
+          'type' => '17516'
         }
       },
       'Reg' => {
@@ -2869,73 +2869,73 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_activate_firmware_resp'
     },
-    '37594' => {
+    '46000' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1591',
+      'Line' => '1885',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'self_contained_activation_req',
-          'type' => '30217'
+          'type' => '34885'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '3' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_activate_firmware_req'
     },
-    '37836' => {
+    '46612' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1576',
+      'Line' => '1870',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '3' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_apply_complete_resp'
     },
-    '38026' => {
+    '47523' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1559',
+      'Line' => '1838',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'apply_result',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'comp_activation_methods_modification',
-          'type' => '38136'
+          'type' => '47633'
         }
       },
       'Reg' => {
@@ -2947,45 +2947,45 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_apply_complete_req'
     },
-    '38146' => {
+    '47643' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1546',
+      'Line' => '1825',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '3' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_verify_complete_resp'
     },
-    '38336' => {
+    '48415' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1531',
+      'Line' => '1796',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'verify_result',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -2996,45 +2996,45 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_verify_complete_req'
     },
-    '38412' => {
+    '48491' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1520',
+      'Line' => '1785',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '3' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_transfer_complete_resp'
     },
-    '38602' => {
+    '49263' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1504',
+      'Line' => '1755',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'transfer_result',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -3045,25 +3045,25 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_transfer_complete_req'
     },
-    '38678' => {
+    '49339' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1491',
+      'Line' => '1742',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '3' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
@@ -3072,25 +3072,25 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_request_firmware_data_resp'
     },
-    '38868' => {
+    '50264' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1469',
+      'Line' => '1703',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'offset',
-          'type' => '4924'
+          'type' => '1668'
         },
         '3' => {
           'name' => 'length',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Reg' => {
@@ -3102,38 +3102,38 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_request_firmware_data_req'
     },
-    '38988' => {
+    '51503' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1451',
+      'Line' => '1670',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'comp_compatibility_resp',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'comp_compatibility_resp_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'update_option_flags_enabled',
-          'type' => '37287'
+          'type' => '44972'
         },
         '6' => {
           'name' => 'time_before_req_fw_data',
           'offset' => '0',
-          'type' => '12863'
+          'type' => '17516'
         }
       },
       'Reg' => {
@@ -3145,91 +3145,91 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_update_component_resp'
     },
-    '39222' => {
+    '53756' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1427',
+      'Line' => '1634',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'comp_classification',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'comp_identifier',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'comp_classification_index',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'comp_comparison_stamp',
-          'type' => '1018'
+          'type' => '147'
         },
         '5' => {
           'name' => 'comp_image_size',
-          'type' => '1018'
+          'type' => '147'
         },
         '6' => {
           'name' => 'update_option_flags',
           'offset' => '0',
-          'type' => '30993'
+          'type' => '35661'
         },
         '7' => {
           'name' => 'comp_ver_str_type',
           'offset' => '8',
-          'type' => '121'
+          'type' => '135'
         },
         '8' => {
           'name' => 'comp_ver_str_len',
           'offset' => '16',
-          'type' => '121'
+          'type' => '135'
         },
         '9' => {
           'name' => 'comp_ver_str',
           'offset' => '24',
-          'type' => '39690'
+          'type' => '54224'
         },
         '10' => {
           'name' => 'msg',
           'offset' => '32',
-          'type' => '4270'
+          'type' => '1443'
         },
         '11' => {
           'name' => 'payload_length',
           'offset' => '40',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_update_component_req'
     },
-    '39700' => {
+    '55069' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1400',
+      'Line' => '1591',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '32000'
+          'type' => '36668'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'comp_resp',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'comp_resp_code',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -3240,86 +3240,86 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_pass_component_table_resp'
     },
-    '39899' => {
+    '57087' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1382',
+      'Line' => '1561',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'transfer_flag',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'comp_classification',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'comp_identifier',
-          'type' => '1006'
+          'type' => '5660'
         },
         '4' => {
           'name' => 'comp_classification_index',
-          'type' => '121'
+          'type' => '135'
         },
         '5' => {
           'name' => 'comp_comparison_stamp',
-          'type' => '1018'
+          'type' => '147'
         },
         '6' => {
           'name' => 'comp_ver_str_type',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '7' => {
           'name' => 'comp_ver_str_len',
           'offset' => '8',
-          'type' => '121'
+          'type' => '135'
         },
         '8' => {
           'name' => 'comp_ver_str',
           'offset' => '16',
-          'type' => '39690'
+          'type' => '54224'
         },
         '9' => {
           'name' => 'msg',
           'offset' => '24',
-          'type' => '4270'
+          'type' => '1443'
         },
         '10' => {
           'name' => 'payload_length',
           'offset' => '32',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_pass_component_table_req'
     },
-    '40384' => {
+    '58416' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1357',
+      'Line' => '1520',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'fd_meta_data_len',
-          'type' => '12863'
+          'type' => '17516'
         },
         '4' => {
           'name' => 'fd_will_send_pkg_data',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -3331,184 +3331,184 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_request_update_resp'
     },
-    '40531' => {
+    '60248' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1338',
+      'Line' => '1487',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'max_transfer_size',
-          'type' => '1018'
+          'type' => '147'
         },
         '2' => {
           'name' => 'num_of_comp',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'max_outstanding_transfer_req',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'pkg_data_len',
-          'type' => '1006'
+          'type' => '5660'
         },
         '5' => {
           'name' => 'comp_image_set_ver_str_type',
-          'type' => '121'
+          'type' => '135'
         },
         '6' => {
           'name' => 'comp_image_set_ver_str_len',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '7' => {
           'name' => 'comp_img_set_ver_str',
           'offset' => '8',
-          'type' => '39690'
+          'type' => '54224'
         },
         '8' => {
           'name' => 'msg',
           'offset' => '16',
-          'type' => '4270'
+          'type' => '1443'
         },
         '9' => {
           'name' => 'payload_length',
           'offset' => '24',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_request_update_req'
     },
-    '40974' => {
+    '60691' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1248',
+      'Line' => '1397',
       'Param' => {
         '0' => {
           'name' => 'iter',
-          'type' => '43532'
+          'type' => '63257'
         },
         '1' => {
           'name' => 'entry',
-          'type' => '43537'
+          'type' => '63262'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_pldm_downstream_device_parameters_entry_from_iter'
     },
-    '43547' => {
+    '63267' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1219',
+      'Line' => '1368',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'resp_data',
-          'type' => '44902'
+          'type' => '64622'
         },
         '3' => {
           'name' => 'iter',
-          'type' => '43532'
+          'type' => '63257'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_get_downstream_firmware_parameters_resp'
     },
-    '44907' => {
+    '64627' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1193',
+      'Line' => '1342',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'params_req',
-          'type' => '45592'
+          'type' => '65310'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '3' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
-        '2' => 'r14'
+        '2' => 'r12'
       },
       'Return' => '100',
       'ShortName' => 'encode_get_downstream_firmware_parameters_req'
     },
-    '45597' => {
+    '65315' => {
       'Header' => 'firmware_update.h',
-      'Line' => '597',
+      'Line' => '650',
       'Param' => {
         '0' => {
           'name' => 'iter',
-          'type' => '46348'
+          'type' => '66066'
         },
         '1' => {
           'name' => 'dev',
-          'type' => '46353'
+          'type' => '66071'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_pldm_downstream_device_from_iter'
     },
-    '46358' => {
+    '66076' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1172',
+      'Line' => '1321',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'resp_data',
-          'type' => '47726'
+          'type' => '67444'
         },
         '3' => {
           'name' => 'iter',
-          'type' => '46348'
+          'type' => '66066'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_query_downstream_identifiers_resp'
     },
-    '47731' => {
+    '67449' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1155',
+      'Line' => '1304',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'params_req',
-          'type' => '48414'
+          'type' => '68132'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '3' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
@@ -3517,21 +3517,21 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_query_downstream_identifiers_req'
     },
-    '48419' => {
+    '68137' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1136',
+      'Line' => '1285',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'resp_data',
-          'type' => '49718'
+          'type' => '69436'
         }
       },
       'Reg' => {
@@ -3540,17 +3540,17 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_query_downstream_devices_resp'
     },
-    '49723' => {
+    '69441' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1120',
+      'Line' => '1269',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Reg' => {
@@ -3560,29 +3560,29 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_query_downstream_devices_req'
     },
-    '49843' => {
+    '69561' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1102',
+      'Line' => '1223',
       'Param' => {
         '0' => {
           'name' => 'data',
-          'type' => '1214'
+          'type' => '5868'
         },
         '1' => {
           'name' => 'length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'component_data',
-          'type' => '50165'
+          'type' => '69883'
         },
         '3' => {
           'name' => 'active_comp_ver_str',
-          'type' => '10781'
+          'type' => '15434'
         },
         '4' => {
           'name' => 'pending_comp_ver_str',
-          'type' => '10781'
+          'type' => '15434'
         }
       },
       'Reg' => {
@@ -3594,33 +3594,33 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_firmware_parameters_resp_comp_entry'
     },
-    '50170' => {
+    '74683' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1083',
+      'Line' => '1204',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'resp_data',
-          'type' => '50390'
+          'type' => '74903'
         },
         '3' => {
           'name' => 'active_comp_image_set_ver_str',
-          'type' => '10781'
+          'type' => '15434'
         },
         '4' => {
           'name' => 'pending_comp_image_set_ver_str',
-          'type' => '10781'
+          'type' => '15434'
         },
         '5' => {
           'name' => 'comp_parameter_table',
-          'type' => '10781'
+          'type' => '15434'
         }
       },
       'Reg' => {
@@ -3634,21 +3634,21 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_firmware_parameters_resp'
     },
-    '50395' => {
+    '74908' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1066',
+      'Line' => '1187',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Reg' => {
@@ -3659,33 +3659,33 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_get_firmware_parameters_req'
     },
-    '50535' => {
+    '76603' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1048',
+      'Line' => '1169',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'device_identifiers_len',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'descriptor_count',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'descriptor_data',
-          'type' => '50691'
+          'type' => '76759'
         }
       },
       'Reg' => {
@@ -3697,21 +3697,21 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_query_device_identifiers_resp'
     },
-    '50701' => {
+    '76769' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1033',
+      'Line' => '1135',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Reg' => {
@@ -3722,245 +3722,215 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_query_device_identifiers_req'
     },
-    '50841' => {
+    '76909' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1017',
+      'Line' => '1119',
       'Param' => {
         '0' => {
           'name' => 'data',
-          'type' => '1214'
+          'type' => '5868'
         },
         '1' => {
           'name' => 'length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'pldm_comp_image_info',
-          'type' => '50988'
+          'type' => '77101'
         },
         '3' => {
           'name' => 'comp_version_str',
-          'type' => '10781'
+          'type' => '15434'
         }
-      },
-      'Reg' => {
-        '0' => 'rbx',
-        '1' => 'r13',
-        '2' => 'rbp',
-        '3' => 'r12'
       },
       'Return' => '100',
       'ShortName' => 'decode_pldm_comp_image_info'
     },
-    '50993' => {
+    '77254' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1002',
+      'Line' => '1104',
       'Param' => {
         '0' => {
           'name' => 'data',
-          'type' => '1214'
+          'type' => '5868'
         },
         '1' => {
           'name' => 'length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'descriptor_title_str_type',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'descriptor_title_str',
-          'type' => '10781'
+          'type' => '15434'
         },
         '4' => {
           'name' => 'descriptor_data',
-          'type' => '10781'
+          'type' => '15434'
         }
-      },
-      'Reg' => {
-        '0' => 'rbx',
-        '1' => 'rbp',
-        '2' => 'r14',
-        '3' => 'r12',
-        '4' => 'r13'
       },
       'Return' => '100',
       'ShortName' => 'decode_vendor_defined_descriptor_value'
     },
-    '51175' => {
+    '77656' => {
       'Header' => 'firmware_update.h',
-      'Line' => '986',
+      'Line' => '1088',
       'Param' => {
         '0' => {
           'name' => 'data',
-          'type' => '1214'
+          'type' => '5868'
         },
         '1' => {
           'name' => 'length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'descriptor_type',
-          'type' => '12863'
+          'type' => '17516'
         },
         '3' => {
           'name' => 'descriptor_data',
-          'type' => '10781'
+          'type' => '15434'
         }
-      },
-      'Reg' => {
-        '0' => 'rbx',
-        '1' => 'r12',
-        '3' => 'rbp'
       },
       'Return' => '100',
       'ShortName' => 'decode_descriptor_type_length_value'
     },
-    '51347' => {
+    '78021' => {
       'Header' => 'firmware_update.h',
-      'Line' => '686',
+      'Line' => '739',
       'Param' => {
         '0' => {
           'name' => 'iter',
-          'type' => '52278'
+          'type' => '78952'
         },
         '1' => {
           'name' => 'desc',
-          'type' => '52283'
+          'type' => '78957'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_pldm_descriptor_from_iter'
     },
-    '52288' => {
+    '78962' => {
       'Header' => 'firmware_update.h',
-      'Line' => '967',
+      'Line' => '1069',
       'Param' => {
         '0' => {
           'name' => 'data',
-          'type' => '1214'
+          'type' => '5868'
         },
         '1' => {
           'name' => 'length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'component_bitmap_bit_length',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'fw_device_id_record',
-          'type' => '52545'
+          'type' => '79242'
         },
         '4' => {
           'name' => 'applicable_components',
-          'type' => '10781'
+          'type' => '15434'
         },
         '5' => {
           'name' => 'comp_image_set_version_str',
-          'type' => '10781'
+          'type' => '15434'
         },
         '6' => {
           'name' => 'record_descriptors',
           'offset' => '0',
-          'type' => '10781'
+          'type' => '15434'
         },
         '7' => {
           'name' => 'fw_device_pkg_data',
           'offset' => '8',
-          'type' => '10781'
+          'type' => '15434'
         }
-      },
-      'Reg' => {
-        '1' => 'r15',
-        '3' => 'rbp',
-        '4' => 'r14',
-        '5' => 'r13'
       },
       'Return' => '100',
       'ShortName' => 'decode_firmware_device_id_record'
     },
-    '52550' => {
+    '79505' => {
       'Header' => 'firmware_update.h',
-      'Line' => '946',
+      'Line' => '1048',
       'Param' => {
         '0' => {
           'name' => 'data',
-          'type' => '1214'
+          'type' => '5868'
         },
         '1' => {
           'name' => 'length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'package_header_info',
-          'type' => '52855'
+          'type' => '79697'
         },
         '3' => {
           'name' => 'package_version_str',
-          'type' => '10781'
+          'type' => '15434'
         }
-      },
-      'Reg' => {
-        '0' => 'rbx',
-        '1' => 'r13',
-        '2' => 'rbp',
-        '3' => 'r12'
       },
       'Return' => '100',
       'ShortName' => 'decode_pldm_package_header_info'
     },
-    '55817' => {
+    '83567' => {
       'Header' => 'fru.h',
       'Line' => '502',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'next_data_transfer_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '4' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_set_fru_record_table_resp'
     },
-    '56057' => {
+    '83807' => {
       'Header' => 'fru.h',
       'Line' => '487',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'data_transfer_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '3' => {
           'name' => 'transfer_flag',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'fru_table_data',
-          'type' => '10781'
+          'type' => '15434'
         }
       },
       'Reg' => {
@@ -3972,80 +3942,80 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_set_fru_record_table_req'
     },
-    '56224' => {
+    '83974' => {
       'Header' => 'fru.h',
       'Line' => '360',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'next_data_transfer_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'transfer_flag',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'fru_record_table_data',
-          'type' => '4919'
+          'type' => '1186'
         },
         '6' => {
           'name' => 'fru_record_table_length',
           'offset' => '0',
-          'type' => '13426'
+          'type' => '2697'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_get_fru_record_table_resp'
     },
-    '56454' => {
+    '84204' => {
       'Header' => 'fru.h',
       'Line' => '387',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'next_data_transfer_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'transfer_flag',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'fru_record_table_data',
-          'type' => '4919'
+          'type' => '1186'
         },
         '6' => {
           'name' => 'fru_record_table_length',
           'offset' => '0',
-          'type' => '13426'
+          'type' => '2697'
         },
         '7' => {
           'name' => 'max_fru_record_table_length',
           'offset' => '8',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
@@ -4056,61 +4026,61 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_fru_record_table_resp_safe'
     },
-    '56775' => {
+    '84525' => {
       'Header' => 'fru.h',
       'Line' => '339',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'data_transfer_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '2' => {
           'name' => 'transfer_operation_flag',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '4' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_fru_record_table_req'
     },
-    '57010' => {
+    '84760' => {
       'Header' => 'fru.h',
       'Line' => '451',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'next_transfer_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'transfer_flag',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'fru_structure_data',
-          'type' => '10781'
+          'type' => '15434'
         }
       },
       'Reg' => {
@@ -4123,43 +4093,43 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_fru_record_by_option_resp'
     },
-    '57177' => {
+    '84927' => {
       'Header' => 'fru.h',
       'Line' => '313',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'next_data_transfer_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'transfer_flag',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'fru_structure_data',
-          'type' => '2396'
+          'type' => '1262'
         },
         '5' => {
           'name' => 'data_size',
-          'type' => '1140'
+          'type' => '164'
         },
         '6' => {
           'name' => 'msg',
           'offset' => '0',
-          'type' => '4270'
+          'type' => '1443'
         },
         '7' => {
           'name' => 'payload_length',
           'offset' => '8',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
@@ -4168,43 +4138,43 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_get_fru_record_by_option_resp'
     },
-    '57568' => {
+    '85318' => {
       'Header' => 'fru.h',
       'Line' => '292',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'data_transfer_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '3' => {
           'name' => 'fru_table_handle',
-          'type' => '12863'
+          'type' => '17516'
         },
         '4' => {
           'name' => 'record_set_identifier',
-          'type' => '12863'
+          'type' => '17516'
         },
         '5' => {
           'name' => 'record_type',
-          'type' => '4919'
+          'type' => '1186'
         },
         '6' => {
           'name' => 'field_type',
           'offset' => '0',
-          'type' => '4919'
+          'type' => '1186'
         },
         '7' => {
           'name' => 'transfer_op_flag',
           'offset' => '8',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -4217,132 +4187,132 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_fru_record_by_option_req'
     },
-    '57770' => {
+    '85520' => {
       'Header' => 'fru.h',
       'Line' => '433',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'data_transfer_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '2' => {
           'name' => 'fru_table_handle',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'record_set_identifier',
-          'type' => '1006'
+          'type' => '5660'
         },
         '4' => {
           'name' => 'record_type',
-          'type' => '121'
+          'type' => '135'
         },
         '5' => {
           'name' => 'field_type',
-          'type' => '121'
+          'type' => '135'
         },
         '6' => {
           'name' => 'transfer_op_flag',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '7' => {
           'name' => 'msg',
           'offset' => '8',
-          'type' => '4270'
+          'type' => '1443'
         },
         '8' => {
           'name' => 'payload_length',
           'offset' => '16',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_fru_record_by_option_req'
     },
-    '58067' => {
+    '85817' => {
       'Header' => 'fru.h',
       'Line' => '468',
       'Param' => {
         '0' => {
           'name' => 'table',
-          'type' => '1214'
+          'type' => '5868'
         },
         '1' => {
           'name' => 'table_size',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'record_table',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'record_size',
-          'type' => '13426'
+          'type' => '2697'
         },
         '4' => {
           'name' => 'rsi',
-          'type' => '1006'
+          'type' => '5660'
         },
         '5' => {
           'name' => 'rt',
-          'type' => '121'
+          'type' => '135'
         },
         '6' => {
           'name' => 'ft',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         }
       },
       'Return' => '100',
       'ShortName' => 'get_fru_record_by_option'
     },
-    '58727' => {
+    '86477' => {
       'Header' => 'fru.h',
       'Line' => '409',
       'Param' => {
         '0' => {
           'name' => 'fru_table',
-          'type' => '4919'
+          'type' => '1186'
         },
         '1' => {
           'name' => 'total_size',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'curr_size',
-          'type' => '13426'
+          'type' => '2697'
         },
         '3' => {
           'name' => 'record_set_id',
-          'type' => '1006'
+          'type' => '5660'
         },
         '4' => {
           'name' => 'record_type',
-          'type' => '121'
+          'type' => '135'
         },
         '5' => {
           'name' => 'num_frus',
-          'type' => '121'
+          'type' => '135'
         },
         '6' => {
           'name' => 'encoding',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '7' => {
           'name' => 'tlvs',
           'offset' => '8',
-          'type' => '4919'
+          'type' => '1186'
         },
         '8' => {
           'name' => 'tlvs_size',
           'offset' => '16',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
@@ -4354,53 +4324,53 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_fru_record'
     },
-    '59049' => {
+    '86799' => {
       'Header' => 'fru.h',
       'Line' => '269',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'next_data_transfer_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'transfer_flag',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_fru_record_table_resp'
     },
-    '59271' => {
+    '87021' => {
       'Header' => 'fru.h',
       'Line' => '251',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'data_transfer_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '3' => {
           'name' => 'transfer_operation_flag',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -4412,105 +4382,105 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_fru_record_table_req'
     },
-    '59375' => {
+    '87125' => {
       'Header' => 'fru.h',
       'Line' => '232',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'fru_data_major_version',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'fru_data_minor_version',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'fru_table_maximum_size',
-          'type' => '1018'
+          'type' => '147'
         },
         '5' => {
           'name' => 'fru_table_length',
-          'type' => '1018'
+          'type' => '147'
         },
         '6' => {
           'name' => 'total_record_set_identifiers',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '7' => {
           'name' => 'total_table_records',
           'offset' => '8',
-          'type' => '1006'
+          'type' => '5660'
         },
         '8' => {
           'name' => 'checksum',
           'offset' => '16',
-          'type' => '1018'
+          'type' => '147'
         },
         '9' => {
           'name' => 'msg',
           'offset' => '24',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_fru_record_table_metadata_resp'
     },
-    '59678' => {
+    '87428' => {
       'Header' => 'fru.h',
       'Line' => '203',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'fru_data_major_version',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'fru_data_minor_version',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'fru_table_maximum_size',
-          'type' => '4924'
+          'type' => '1668'
         },
         '6' => {
           'name' => 'fru_table_length',
           'offset' => '0',
-          'type' => '4924'
+          'type' => '1668'
         },
         '7' => {
           'name' => 'total_record_set_identifiers',
           'offset' => '8',
-          'type' => '12863'
+          'type' => '17516'
         },
         '8' => {
           'name' => 'total_table_records',
           'offset' => '16',
-          'type' => '12863'
+          'type' => '17516'
         },
         '9' => {
           'name' => 'checksum',
           'offset' => '24',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Reg' => {
@@ -4523,45 +4493,45 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_fru_record_table_metadata_resp'
     },
-    '59888' => {
+    '87638' => {
       'Header' => 'fru.h',
       'Line' => '178',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '2' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_fru_record_table_metadata_req'
     },
-    '76701' => {
+    '104485' => {
       'Header' => 'pdr.h',
       'Line' => '638',
       'Param' => {
         '0' => {
           'name' => 'pdr',
-          'type' => '1214'
+          'type' => '5868'
         },
         '1' => {
           'name' => 'pdr_len',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'num_entities',
-          'type' => '13426'
+          'type' => '2697'
         },
         '3' => {
           'name' => 'entities',
-          'type' => '77026'
+          'type' => '104810'
         }
       },
       'Reg' => {
@@ -4571,28 +4541,28 @@ $VAR1 = {
       'Return' => '1',
       'ShortName' => 'pldm_entity_association_pdr_extract'
     },
-    '77041' => {
+    '104825' => {
       'Header' => 'pdr.h',
       'Line' => '626',
       'Param' => {
         '0' => {
           'name' => 'tree',
-          'type' => '77090'
+          'type' => '104874'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '805',
+      'Return' => '5459',
       'ShortName' => 'pldm_is_empty_entity_assoc_tree'
     },
-    '77095' => {
+    '104879' => {
       'Header' => 'pdr.h',
       'Line' => '616',
       'Param' => {
         '0' => {
           'name' => 'tree',
-          'type' => '77090'
+          'type' => '104874'
         }
       },
       'Reg' => {
@@ -4601,89 +4571,89 @@ $VAR1 = {
       'Return' => '1',
       'ShortName' => 'pldm_entity_association_tree_destroy_root'
     },
-    '77254' => {
+    '105038' => {
       'Header' => 'pdr.h',
       'Line' => '593',
       'Param' => {
         '0' => {
           'name' => 'org_tree',
-          'type' => '77090'
+          'type' => '104874'
         },
         '1' => {
           'name' => 'new_tree',
-          'type' => '77090'
+          'type' => '104874'
         }
       },
       'Return' => '1',
       'ShortName' => 'pldm_entity_association_tree_copy_root'
     },
-    '77683' => {
+    '105467' => {
       'Header' => 'pdr.h',
       'Line' => '567',
       'Param' => {
         '0' => {
           'name' => 'tree',
-          'type' => '77090'
+          'type' => '104874'
         },
         '1' => {
           'name' => 'entity',
-          'type' => '67691'
+          'type' => '95475'
         }
       },
-      'Return' => '61702',
+      'Return' => '89452',
       'ShortName' => 'pldm_entity_association_tree_find'
     },
-    '77963' => {
+    '105747' => {
       'Header' => 'pdr.h',
       'Line' => '581',
       'Param' => {
         '0' => {
           'name' => 'tree',
-          'type' => '77090'
+          'type' => '104874'
         },
         '1' => {
           'name' => 'entity',
-          'type' => '67691'
+          'type' => '95475'
         },
         '2' => {
           'name' => 'is_remote',
-          'type' => '805'
+          'type' => '5459'
         }
       },
-      'Return' => '61702',
+      'Return' => '89452',
       'ShortName' => 'pldm_entity_association_tree_find_with_locality'
     },
-    '78345' => {
+    '106129' => {
       'Header' => 'pdr.h',
       'Line' => '213',
       'Param' => {
         '0' => {
           'name' => 'repo',
-          'type' => '78467'
+          'type' => '106251'
         },
         '1' => {
           'name' => 'first',
-          'type' => '1018'
+          'type' => '147'
         },
         '2' => {
           'name' => 'last',
-          'type' => '1018'
+          'type' => '147'
         }
       },
       'Reg' => {
         '1' => 'rsi',
         '2' => 'rdx'
       },
-      'Return' => '61697',
+      'Return' => '89447',
       'ShortName' => 'pldm_pdr_find_last_in_range'
     },
-    '78472' => {
+    '106256' => {
       'Header' => 'pdr.h',
       'Line' => '178',
       'Param' => {
         '0' => {
           'name' => 'repo',
-          'type' => '62571'
+          'type' => '90321'
         }
       },
       'Reg' => {
@@ -4692,17 +4662,17 @@ $VAR1 = {
       'Return' => '1',
       'ShortName' => 'pldm_pdr_remove_remote_pdrs'
     },
-    '78724' => {
+    '106508' => {
       'Header' => 'pdr.h',
       'Line' => '187',
       'Param' => {
         '0' => {
           'name' => 'repo',
-          'type' => '62571'
+          'type' => '90321'
         },
         '1' => {
           'name' => 'terminus_handle',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Reg' => {
@@ -4712,58 +4682,58 @@ $VAR1 = {
       'Return' => '1',
       'ShortName' => 'pldm_pdr_remove_pdrs_by_terminus_handle'
     },
-    '78992' => {
+    '106776' => {
       'Header' => 'pdr.h',
       'Line' => '528',
       'Param' => {
         '0' => {
           'name' => 'tree',
-          'type' => '77090'
+          'type' => '104874'
         },
         '1' => {
           'name' => 'entity',
-          'type' => '60835'
+          'type' => '88585'
         },
         '2' => {
           'name' => 'node',
-          'type' => '77678'
+          'type' => '105462'
         }
       },
       'Return' => '1',
       'ShortName' => 'pldm_find_entity_ref_in_tree'
     },
-    '79279' => {
+    '107063' => {
       'Header' => 'pdr.h',
       'Line' => '517',
       'Param' => {
         '0' => {
           'name' => 'node',
-          'type' => '61702'
+          'type' => '89452'
         },
         '1' => {
           'name' => 'repo',
-          'type' => '62571'
+          'type' => '90321'
         },
         '2' => {
           'name' => 'entities',
-          'type' => '77026'
+          'type' => '104810'
         },
         '3' => {
           'name' => 'num_entities',
-          'type' => '1140'
+          'type' => '164'
         },
         '4' => {
           'name' => 'is_remote',
-          'type' => '805'
+          'type' => '5459'
         },
         '5' => {
           'name' => 'terminus_handle',
-          'type' => '1006'
+          'type' => '5660'
         },
         '6' => {
           'name' => 'record_handle',
           'offset' => '0',
-          'type' => '1018'
+          'type' => '147'
         }
       },
       'Reg' => {
@@ -4777,148 +4747,148 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_entity_association_pdr_add_from_node_with_record_handle'
     },
-    '79512' => {
+    '107296' => {
       'Header' => 'pdr.h',
       'Line' => '500',
       'Param' => {
         '0' => {
           'name' => 'node',
-          'type' => '61702'
+          'type' => '89452'
         },
         '1' => {
           'name' => 'repo',
-          'type' => '62571'
+          'type' => '90321'
         },
         '2' => {
           'name' => 'entities',
-          'type' => '77026'
+          'type' => '104810'
         },
         '3' => {
           'name' => 'num_entities',
-          'type' => '1140'
+          'type' => '164'
         },
         '4' => {
           'name' => 'is_remote',
-          'type' => '805'
+          'type' => '5459'
         },
         '5' => {
           'name' => 'terminus_handle',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Return' => '100',
       'ShortName' => 'pldm_entity_association_pdr_add_from_node'
     },
-    '79730' => {
+    '107514' => {
       'Header' => 'pdr.h',
       'Line' => '451',
       'Param' => {
         '0' => {
           'name' => 'tree',
-          'type' => '77090'
+          'type' => '104874'
         },
         '1' => {
           'name' => 'repo',
-          'type' => '62571'
+          'type' => '90321'
         },
         '2' => {
           'name' => 'is_remote',
-          'type' => '805'
+          'type' => '5459'
         },
         '3' => {
           'name' => 'terminus_handle',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Return' => '100',
       'ShortName' => 'pldm_entity_association_pdr_add'
     },
-    '81287' => {
+    '109071' => {
       'Header' => 'pdr.h',
       'Line' => '554',
       'Param' => {
         '0' => {
           'name' => 'parent',
-          'type' => '61702'
+          'type' => '89452'
         },
         '1' => {
           'name' => 'node',
-          'type' => '67691'
+          'type' => '95475'
         }
       },
       'Reg' => {
         '0' => 'rdi',
         '1' => 'rsi'
       },
-      'Return' => '805',
+      'Return' => '5459',
       'ShortName' => 'pldm_is_current_parent_child'
     },
-    '81376' => {
+    '109160' => {
       'Header' => 'pdr.h',
       'Line' => '540',
       'Param' => {
         '0' => {
           'name' => 'node',
-          'type' => '61702'
+          'type' => '89452'
         },
         '1' => {
           'name' => 'association_type',
-          'type' => '121'
+          'type' => '135'
         }
       },
       'Reg' => {
         '0' => 'rdi',
         '1' => 'rcx'
       },
-      'Return' => '121',
+      'Return' => '135',
       'ShortName' => 'pldm_entity_get_num_children'
     },
-    '81591' => {
+    '109375' => {
       'Header' => 'pdr.h',
       'Line' => '435',
       'Param' => {
         '0' => {
           'name' => 'node',
-          'type' => '61702'
+          'type' => '89452'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '805',
+      'Return' => '5459',
       'ShortName' => 'pldm_entity_is_exist_parent'
     },
-    '81640' => {
+    '109424' => {
       'Header' => 'pdr.h',
       'Line' => '425',
       'Param' => {
         '0' => {
           'name' => 'node',
-          'type' => '61702'
+          'type' => '89452'
         }
       },
-      'Return' => '60835',
+      'Return' => '88585',
       'ShortName' => 'pldm_entity_get_parent'
     },
-    '81774' => {
+    '109558' => {
       'Header' => 'pdr.h',
       'Line' => '415',
       'Param' => {
         '0' => {
           'name' => 'node',
-          'type' => '61702'
+          'type' => '89452'
         }
       },
-      'Return' => '805',
+      'Return' => '5459',
       'ShortName' => 'pldm_entity_is_node_parent'
     },
-    '81929' => {
+    '109713' => {
       'Header' => 'pdr.h',
       'Line' => '405',
       'Param' => {
         '0' => {
           'name' => 'tree',
-          'type' => '77090'
+          'type' => '104874'
         }
       },
       'Reg' => {
@@ -4927,21 +4897,21 @@ $VAR1 = {
       'Return' => '1',
       'ShortName' => 'pldm_entity_association_tree_destroy'
     },
-    '82108' => {
+    '109892' => {
       'Header' => 'pdr.h',
       'Line' => '377',
       'Param' => {
         '0' => {
           'name' => 'tree',
-          'type' => '77090'
+          'type' => '104874'
         },
         '1' => {
           'name' => 'entities',
-          'type' => '77026'
+          'type' => '104810'
         },
         '2' => {
           'name' => 'size',
-          'type' => '13426'
+          'type' => '2697'
         }
       },
       'Reg' => {
@@ -4950,129 +4920,129 @@ $VAR1 = {
       'Return' => '1',
       'ShortName' => 'pldm_entity_association_tree_visit'
     },
-    '82567' => {
+    '110351' => {
       'Header' => 'pdr.h',
       'Line' => '359',
       'Param' => {
         '0' => {
           'name' => 'tree',
-          'type' => '77090'
+          'type' => '104874'
         },
         '1' => {
           'name' => 'entity',
-          'type' => '67691'
+          'type' => '95475'
         },
         '2' => {
           'name' => 'entity_instance_number',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'parent',
-          'type' => '61702'
+          'type' => '89452'
         },
         '4' => {
           'name' => 'association_type',
-          'type' => '121'
+          'type' => '135'
         },
         '5' => {
           'name' => 'is_remote',
-          'type' => '805'
+          'type' => '5459'
         },
         '6' => {
           'name' => 'is_update_container_id',
           'offset' => '0',
-          'type' => '805'
+          'type' => '5459'
         },
         '7' => {
           'name' => 'container_id',
           'offset' => '8',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
-      'Return' => '61702',
+      'Return' => '89452',
       'ShortName' => 'pldm_entity_association_tree_add_entity'
     },
-    '83174' => {
+    '110958' => {
       'Header' => 'pdr.h',
       'Line' => '331',
       'Param' => {
         '0' => {
           'name' => 'tree',
-          'type' => '77090'
+          'type' => '104874'
         },
         '1' => {
           'name' => 'entity',
-          'type' => '67691'
+          'type' => '95475'
         },
         '2' => {
           'name' => 'entity_instance_number',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'parent',
-          'type' => '61702'
+          'type' => '89452'
         },
         '4' => {
           'name' => 'association_type',
-          'type' => '121'
+          'type' => '135'
         }
       },
-      'Return' => '61702',
+      'Return' => '89452',
       'ShortName' => 'pldm_entity_association_tree_add'
     },
-    '83497' => {
+    '111281' => {
       'Header' => 'pdr.h',
       'Line' => '314',
-      'Return' => '77090',
+      'Return' => '104874',
       'ShortName' => 'pldm_entity_association_tree_init'
     },
-    '83571' => {
+    '111355' => {
       'Header' => 'pdr.h',
       'Line' => '399',
       'Param' => {
         '0' => {
           'name' => 'entity',
-          'type' => '83705'
+          'type' => '111489'
         }
       },
-      'Return' => '1006',
+      'Return' => '5660',
       'ShortName' => 'pldm_entity_node_get_remote_container_id'
     },
-    '83731' => {
+    '111515' => {
       'Header' => 'pdr.h',
       'Line' => '388',
       'Param' => {
         '0' => {
           'name' => 'node',
-          'type' => '61702'
+          'type' => '89452'
         }
       },
-      'Return' => '60835',
+      'Return' => '88585',
       'ShortName' => 'pldm_entity_extract'
     },
-    '84327' => {
+    '112111' => {
       'Header' => 'pdr.h',
       'Line' => '200',
       'Param' => {
         '0' => {
           'name' => 'repo',
-          'type' => '78467'
+          'type' => '106251'
         },
         '1' => {
           'name' => 'terminus_handle',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'tid',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'tl_eid',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'valid_bit',
-          'type' => '805'
+          'type' => '5459'
         }
       },
       'Reg' => {
@@ -5084,153 +5054,153 @@ $VAR1 = {
       'Return' => '1',
       'ShortName' => 'pldm_pdr_update_TL_pdr'
     },
-    '84681' => {
+    '112465' => {
       'Header' => 'pdr.h',
       'Line' => '279',
       'Param' => {
         '0' => {
           'name' => 'repo',
-          'type' => '78467'
+          'type' => '106251'
         },
         '1' => {
           'name' => 'fru_rsi',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'terminus_handle',
-          'type' => '12863'
+          'type' => '17516'
         },
         '3' => {
           'name' => 'entity_type',
-          'type' => '12863'
+          'type' => '17516'
         },
         '4' => {
           'name' => 'entity_instance_num',
-          'type' => '12863'
+          'type' => '17516'
         },
         '5' => {
           'name' => 'container_id',
-          'type' => '12863'
+          'type' => '17516'
         }
       },
       'Reg' => {
         '2' => 'r12'
       },
-      'Return' => '63521',
+      'Return' => '91271',
       'ShortName' => 'pldm_pdr_fru_record_set_find_by_rsi'
     },
-    '85035' => {
+    '112819' => {
       'Header' => 'pdr.h',
       'Line' => '258',
       'Param' => {
         '0' => {
           'name' => 'repo',
-          'type' => '62571'
+          'type' => '90321'
         },
         '1' => {
           'name' => 'terminus_handle',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'fru_rsi',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'entity_type',
-          'type' => '1006'
+          'type' => '5660'
         },
         '4' => {
           'name' => 'entity_instance_num',
-          'type' => '1006'
+          'type' => '5660'
         },
         '5' => {
           'name' => 'container_id',
-          'type' => '1006'
+          'type' => '5660'
         },
         '6' => {
           'name' => 'bmc_record_handle',
           'offset' => '0',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Return' => '100',
       'ShortName' => 'pldm_pdr_add_fru_record_set'
     },
-    '85348' => {
+    '113132' => {
       'Header' => 'pdr.h',
       'Line' => '170',
       'Param' => {
         '0' => {
           'name' => 'record',
-          'type' => '63521'
+          'type' => '91271'
         }
       },
-      'Return' => '805',
+      'Return' => '5459',
       'ShortName' => 'pldm_pdr_record_is_remote'
     },
-    '85719' => {
+    '113503' => {
       'Header' => 'pdr.h',
       'Line' => '94',
       'Param' => {
         '0' => {
           'name' => 'repo',
-          'type' => '78467'
+          'type' => '106251'
         },
         '1' => {
           'name' => 'record',
-          'type' => '63521'
+          'type' => '91271'
         }
       },
-      'Return' => '1018',
+      'Return' => '147',
       'ShortName' => 'pldm_pdr_get_record_handle'
     },
-    '85936' => {
+    '113720' => {
       'Header' => 'pdr.h',
       'Line' => '62',
       'Param' => {
         '0' => {
           'name' => 'repo',
-          'type' => '78467'
+          'type' => '106251'
         }
       },
-      'Return' => '1018',
+      'Return' => '147',
       'ShortName' => 'pldm_pdr_get_repo_size'
     },
-    '86067' => {
+    '113853' => {
       'Header' => 'pdr.h',
       'Line' => '52',
       'Param' => {
         '0' => {
           'name' => 'repo',
-          'type' => '78467'
+          'type' => '106251'
         }
       },
-      'Return' => '1018',
+      'Return' => '147',
       'ShortName' => 'pldm_pdr_get_record_count'
     },
-    '86198' => {
+    '113984' => {
       'Header' => 'pdr.h',
       'Line' => '160',
       'Param' => {
         '0' => {
           'name' => 'repo',
-          'type' => '78467'
+          'type' => '106251'
         },
         '1' => {
           'name' => 'pdr_type',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'curr_record',
-          'type' => '63521'
+          'type' => '91271'
         },
         '3' => {
           'name' => 'data',
-          'type' => '50691'
+          'type' => '76759'
         },
         '4' => {
           'name' => 'size',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Reg' => {
@@ -5238,32 +5208,32 @@ $VAR1 = {
         '3' => 'rcx',
         '4' => 'r8'
       },
-      'Return' => '63521',
+      'Return' => '91271',
       'ShortName' => 'pldm_pdr_find_record_by_type'
     },
-    '86369' => {
+    '114155' => {
       'Header' => 'pdr.h',
       'Line' => '142',
       'Param' => {
         '0' => {
           'name' => 'repo',
-          'type' => '78467'
+          'type' => '106251'
         },
         '1' => {
           'name' => 'curr_record',
-          'type' => '63521'
+          'type' => '91271'
         },
         '2' => {
           'name' => 'data',
-          'type' => '50691'
+          'type' => '76759'
         },
         '3' => {
           'name' => 'size',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'next_record_handle',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Reg' => {
@@ -5273,32 +5243,32 @@ $VAR1 = {
         '3' => 'rcx',
         '4' => 'r8'
       },
-      'Return' => '63521',
+      'Return' => '91271',
       'ShortName' => 'pldm_pdr_get_next_record'
     },
-    '86576' => {
+    '114362' => {
       'Header' => 'pdr.h',
       'Line' => '123',
       'Param' => {
         '0' => {
           'name' => 'repo',
-          'type' => '78467'
+          'type' => '106251'
         },
         '1' => {
           'name' => 'record_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '2' => {
           'name' => 'data',
-          'type' => '50691'
+          'type' => '76759'
         },
         '3' => {
           'name' => 'size',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'next_record_handle',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Reg' => {
@@ -5308,16 +5278,16 @@ $VAR1 = {
         '3' => 'rcx',
         '4' => 'r8'
       },
-      'Return' => '63521',
+      'Return' => '91271',
       'ShortName' => 'pldm_pdr_find_record'
     },
-    '86755' => {
+    '114541' => {
       'Header' => 'pdr.h',
       'Line' => '42',
       'Param' => {
         '0' => {
           'name' => 'repo',
-          'type' => '62571'
+          'type' => '90321'
         }
       },
       'Reg' => {
@@ -5326,39 +5296,39 @@ $VAR1 = {
       'Return' => '1',
       'ShortName' => 'pldm_pdr_destroy'
     },
-    '86908' => {
+    '114694' => {
       'Header' => 'pdr.h',
       'Line' => '36',
-      'Return' => '62571',
+      'Return' => '90321',
       'ShortName' => 'pldm_pdr_init'
     },
-    '86980' => {
+    '114766' => {
       'Header' => 'pdr.h',
       'Line' => '79',
       'Param' => {
         '0' => {
           'name' => 'repo',
-          'type' => '62571'
+          'type' => '90321'
         },
         '1' => {
           'name' => 'data',
-          'type' => '1214'
+          'type' => '5868'
         },
         '2' => {
           'name' => 'size',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'is_remote',
-          'type' => '805'
+          'type' => '5459'
         },
         '4' => {
           'name' => 'terminus_handle',
-          'type' => '1006'
+          'type' => '5660'
         },
         '5' => {
           'name' => 'record_handle',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Reg' => {
@@ -5370,52 +5340,52 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_pdr_add'
     },
-    '94908' => {
+    '122694' => {
       'Header' => 'platform.h',
       'Line' => '2543',
       'Param' => {
         '0' => {
           'name' => 'event',
-          'type' => '94957'
+          'type' => '122743'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '4919',
+      'Return' => '1186',
       'ShortName' => 'pldm_platform_cper_event_event_data'
     },
-    '94962' => {
+    '122748' => {
       'Header' => 'platform.h',
       'Line' => '2532',
       'Param' => {
         '0' => {
           'name' => 'event_data',
-          'type' => '2396'
+          'type' => '1262'
         },
         '1' => {
           'name' => 'event_data_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'cper_event',
-          'type' => '94957'
+          'type' => '122743'
         },
         '3' => {
           'name' => 'cper_event_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_pldm_platform_cper_event'
     },
-    '96099' => {
+    '123885' => {
       'Header' => 'platform.h',
       'Line' => '2521',
       'Param' => {
         '0' => {
           'name' => 'pdr',
-          'type' => '96710'
+          'type' => '124496'
         }
       },
       'Reg' => {
@@ -5424,25 +5394,25 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_pldm_entity_auxiliary_names_pdr_index'
     },
-    '96715' => {
+    '124501' => {
       'Header' => 'platform.h',
       'Line' => '2499',
       'Param' => {
         '0' => {
           'name' => 'data',
-          'type' => '2396'
+          'type' => '1262'
         },
         '1' => {
           'name' => 'data_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'pdr',
-          'type' => '96710'
+          'type' => '124496'
         },
         '3' => {
           'name' => 'pdr_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
@@ -5451,25 +5421,25 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_entity_auxiliary_names_pdr'
     },
-    '100852' => {
+    '128638' => {
       'Header' => 'platform.h',
       'Line' => '1883',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'resp',
-          'type' => '101961'
+          'type' => '129747'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '3' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
@@ -5478,21 +5448,21 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_get_state_effecter_states_resp'
     },
-    '101976' => {
+    '129762' => {
       'Header' => 'platform.h',
       'Line' => '1866',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'resp',
-          'type' => '101961'
+          'type' => '129747'
         }
       },
       'Reg' => {
@@ -5501,211 +5471,211 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_state_effecter_states_resp'
     },
-    '103006' => {
+    '130792' => {
       'Header' => 'platform.h',
       'Line' => '1835',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'effecter_id',
-          'type' => '12863'
+          'type' => '17516'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_get_state_effecter_states_req'
     },
-    '103573' => {
+    '131359' => {
       'Header' => 'platform.h',
       'Line' => '1849',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'effecter_id',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '3' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_state_effecter_states_req'
     },
-    '120193' => {
+    '147979' => {
       'Header' => 'platform.h',
       'Line' => '2015',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'tid',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'event_id',
-          'type' => '12863'
+          'type' => '17516'
         },
         '5' => {
           'name' => 'next_data_transfer_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '6' => {
           'name' => 'transfer_flag',
           'offset' => '0',
-          'type' => '4919'
+          'type' => '1186'
         },
         '7' => {
           'name' => 'event_class',
           'offset' => '8',
-          'type' => '4919'
+          'type' => '1186'
         },
         '8' => {
           'name' => 'event_data_size',
           'offset' => '16',
-          'type' => '4924'
+          'type' => '1668'
         },
         '9' => {
           'name' => 'event_data',
           'offset' => '24',
-          'type' => '53604'
+          'type' => '80830'
         },
         '10' => {
           'name' => 'event_data_integrity_checksum',
           'offset' => '32',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_poll_for_platform_event_message_resp'
     },
-    '122256' => {
+    '150042' => {
       'Header' => 'platform.h',
       'Line' => '1989',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'format_version',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'transfer_operation_flag',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'data_transfer_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '4' => {
           'name' => 'event_id_to_acknowledge',
-          'type' => '1006'
+          'type' => '5660'
         },
         '5' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '6' => {
           'name' => 'payload_length',
           'offset' => '0',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_poll_for_platform_event_message_req'
     },
-    '123347' => {
+    '151133' => {
       'Header' => 'platform.h',
       'Line' => '2459',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_set_event_receiver_resp'
     },
-    '123520' => {
+    '151306' => {
       'Header' => 'platform.h',
       'Line' => '2445',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'event_message_global_enable',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'transport_protocol_type',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'event_receiver_address_info',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'heartbeat_timer',
-          'type' => '12863'
+          'type' => '17516'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_set_event_receiver_req'
     },
-    '124580' => {
+    '152366' => {
       'Header' => 'platform.h',
       'Line' => '2423',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -5716,218 +5686,218 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_set_event_receiver_resp'
     },
-    '125073' => {
+    '152859' => {
       'Header' => 'platform.h',
       'Line' => '2409',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'event_message_global_enable',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'transport_protocol_type',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'event_receiver_address_info',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'heartbeat_timer',
-          'type' => '1006'
+          'type' => '5660'
         },
         '5' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_set_event_receiver_req'
     },
-    '125331' => {
+    '153117' => {
       'Header' => 'platform.h',
       'Line' => '1530',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'sensor_id',
-          'type' => '12863'
+          'type' => '17516'
         },
         '3' => {
           'name' => 'rearm_event_state',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_get_sensor_reading_req'
     },
-    '126087' => {
+    '153873' => {
       'Header' => 'platform.h',
       'Line' => '1556',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'sensor_data_size',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'sensor_operational_state',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'sensor_event_message_enable',
-          'type' => '121'
+          'type' => '135'
         },
         '5' => {
           'name' => 'present_state',
-          'type' => '121'
+          'type' => '135'
         },
         '6' => {
           'name' => 'previous_state',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '7' => {
           'name' => 'event_state',
           'offset' => '8',
-          'type' => '121'
+          'type' => '135'
         },
         '8' => {
           'name' => 'present_reading',
           'offset' => '16',
-          'type' => '1214'
+          'type' => '5868'
         },
         '9' => {
           'name' => 'msg',
           'offset' => '24',
-          'type' => '4270'
+          'type' => '1443'
         },
         '10' => {
           'name' => 'payload_length',
           'offset' => '32',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_sensor_reading_resp'
     },
-    '126641' => {
+    '154427' => {
       'Header' => 'platform.h',
       'Line' => '2384',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'sensor_data_size',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'sensor_operational_state',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'sensor_event_message_enable',
-          'type' => '4919'
+          'type' => '1186'
         },
         '6' => {
           'name' => 'present_state',
           'offset' => '0',
-          'type' => '4919'
+          'type' => '1186'
         },
         '7' => {
           'name' => 'previous_state',
           'offset' => '8',
-          'type' => '4919'
+          'type' => '1186'
         },
         '8' => {
           'name' => 'event_state',
           'offset' => '16',
-          'type' => '4919'
+          'type' => '1186'
         },
         '9' => {
           'name' => 'present_reading',
           'offset' => '24',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_get_sensor_reading_resp'
     },
-    '129286' => {
+    '157072' => {
       'Header' => 'platform.h',
       'Line' => '2359',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'sensor_id',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'rearm_event_state',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_sensor_reading_req'
     },
-    '129504' => {
+    '157290' => {
       'Header' => 'platform.h',
       'Line' => '2340',
       'Param' => {
         '0' => {
           'name' => 'change_record_data',
-          'type' => '1214'
+          'type' => '5868'
         },
         '1' => {
           'name' => 'change_record_data_size',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'event_data_operation',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'number_of_change_entries',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'change_entry_data_offset',
-          'type' => '13426'
+          'type' => '2697'
         }
       },
       'Reg' => {
@@ -5939,49 +5909,49 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_pldm_pdr_repository_change_record_data'
     },
-    '130952' => {
+    '158738' => {
       'Header' => 'platform.h',
       'Line' => '2246',
       'Param' => {
         '0' => {
           'name' => 'event_data',
-          'type' => '2396'
+          'type' => '1262'
         },
         '1' => {
           'name' => 'event_data_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'poll_event',
-          'type' => '131891'
+          'type' => '159677'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_pldm_message_poll_event_data'
     },
-    '131896' => {
+    '159682' => {
       'Header' => 'platform.h',
       'Line' => '2232',
       'Param' => {
         '0' => {
           'name' => 'event_data',
-          'type' => '1214'
+          'type' => '5868'
         },
         '1' => {
           'name' => 'event_data_size',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'event_data_format',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'number_of_change_records',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'change_record_data_offset',
-          'type' => '13426'
+          'type' => '2697'
         }
       },
       'Reg' => {
@@ -5993,43 +5963,43 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_pldm_pdr_repository_chg_event_data'
     },
-    '132566' => {
+    '160352' => {
       'Header' => 'platform.h',
       'Line' => '2294',
       'Param' => {
         '0' => {
           'name' => 'event_data_format',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'number_of_change_records',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'event_data_operations',
-          'type' => '1214'
+          'type' => '5868'
         },
         '3' => {
           'name' => 'numbers_of_change_entries',
-          'type' => '1214'
+          'type' => '5868'
         },
         '4' => {
           'name' => 'change_entries',
-          'type' => '132885'
+          'type' => '160671'
         },
         '5' => {
           'name' => 'event_data',
-          'type' => '132900'
+          'type' => '160686'
         },
         '6' => {
           'name' => 'actual_change_records_size',
           'offset' => '0',
-          'type' => '13426'
+          'type' => '2697'
         },
         '7' => {
           'name' => 'max_change_records_size',
           'offset' => '8',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
@@ -6043,172 +6013,172 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_pldm_pdr_repository_chg_event_data'
     },
-    '132910' => {
+    '160696' => {
       'Header' => 'platform.h',
       'Line' => '2210',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'effecter_data_size',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'effecter_oper_state',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'pending_value',
-          'type' => '4919'
+          'type' => '1186'
         },
         '6' => {
           'name' => 'present_value',
           'offset' => '0',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_get_numeric_effecter_value_resp'
     },
-    '136218' => {
+    '164004' => {
       'Header' => 'platform.h',
       'Line' => '1487',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'effecter_id',
-          'type' => '12863'
+          'type' => '17516'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_get_numeric_effecter_value_req'
     },
-    '136817' => {
+    '164603' => {
       'Header' => 'platform.h',
       'Line' => '1511',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'effecter_data_size',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'effecter_oper_state',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'pending_value',
-          'type' => '1214'
+          'type' => '5868'
         },
         '5' => {
           'name' => 'present_value',
-          'type' => '1214'
+          'type' => '5868'
         },
         '6' => {
           'name' => 'msg',
           'offset' => '0',
-          'type' => '4270'
+          'type' => '1443'
         },
         '7' => {
           'name' => 'payload_length',
           'offset' => '8',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_numeric_effecter_value_resp'
     },
-    '137515' => {
+    '165301' => {
       'Header' => 'platform.h',
       'Line' => '2189',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'effecter_id',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_numeric_effecter_value_req'
     },
-    '137713' => {
+    '165499' => {
       'Header' => 'platform.h',
       'Line' => '2174',
       'Param' => {
         '0' => {
           'name' => 'pdr_data',
-          'type' => '2396'
+          'type' => '1262'
         },
         '1' => {
           'name' => 'pdr_data_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'pdr_value',
-          'type' => '160330'
+          'type' => '188116'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_numeric_sensor_pdr_data'
     },
-    '160335' => {
+    '188121' => {
       'Header' => 'platform.h',
       'Line' => '2162',
       'Param' => {
         '0' => {
           'name' => 'sensor_data',
-          'type' => '1214'
+          'type' => '5868'
         },
         '1' => {
           'name' => 'sensor_data_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'event_state',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'previous_event_state',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'sensor_data_size',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'present_reading',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Reg' => {
@@ -6217,29 +6187,29 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_numeric_sensor_data'
     },
-    '162348' => {
+    '190134' => {
       'Header' => 'platform.h',
       'Line' => '2141',
       'Param' => {
         '0' => {
           'name' => 'sensor_data',
-          'type' => '1214'
+          'type' => '5868'
         },
         '1' => {
           'name' => 'sensor_data_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'sensor_offset',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'event_state',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'previous_event_state',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -6251,25 +6221,25 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_state_sensor_data'
     },
-    '163147' => {
+    '190933' => {
       'Header' => 'platform.h',
       'Line' => '2123',
       'Param' => {
         '0' => {
           'name' => 'sensor_data',
-          'type' => '1214'
+          'type' => '5868'
         },
         '1' => {
           'name' => 'sensor_data_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'present_op_state',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'previous_op_state',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -6280,71 +6250,71 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_sensor_op_data'
     },
-    '163797' => {
+    '191583' => {
       'Header' => 'platform.h',
       'Line' => '2106',
       'Param' => {
         '0' => {
           'name' => 'event_data',
-          'type' => '1214'
+          'type' => '5868'
         },
         '1' => {
           'name' => 'event_data_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'sensor_id',
-          'type' => '12863'
+          'type' => '17516'
         },
         '3' => {
           'name' => 'sensor_event_class_type',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'event_class_data_offset',
-          'type' => '13426'
+          'type' => '2697'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_sensor_event_data'
     },
-    '164606' => {
+    '192392' => {
       'Header' => 'platform.h',
       'Line' => '2085',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'synchrony_config',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'synchrony_config_support',
-          'type' => '6753'
+          'type' => '11406'
         },
         '5' => {
           'name' => 'number_event_class_returned',
-          'type' => '4919'
+          'type' => '1186'
         },
         '6' => {
           'name' => 'event_class',
           'offset' => '0',
-          'type' => '4919'
+          'type' => '1186'
         },
         '7' => {
           'name' => 'event_class_count',
           'offset' => '8',
-          'type' => '121'
+          'type' => '135'
         }
       },
       'Reg' => {
@@ -6354,65 +6324,65 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_event_message_supported_resp'
     },
-    '165884' => {
+    '193670' => {
       'Header' => 'platform.h',
       'Line' => '2068',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'format_version',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_event_message_supported_req'
     },
-    '166082' => {
+    '193868' => {
       'Header' => 'platform.h',
       'Line' => '2041',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'terminus_max_buffer_size',
-          'type' => '12863'
+          'type' => '17516'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_event_message_buffer_size_resp'
     },
-    '166851' => {
+    '194637' => {
       'Header' => 'platform.h',
       'Line' => '2054',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'event_receiver_max_buffer_size',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Reg' => {
@@ -6421,25 +6391,25 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_event_message_buffer_size_req'
     },
-    '167049' => {
+    '194835' => {
       'Header' => 'platform.h',
       'Line' => '2030',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'platform_event_status',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -6448,193 +6418,193 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_platform_event_message_resp'
     },
-    '167725' => {
+    '195511' => {
       'Header' => 'platform.h',
       'Line' => '1973',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'format_version',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'tid',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'event_class',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'event_data',
-          'type' => '1214'
+          'type' => '5868'
         },
         '5' => {
           'name' => 'event_data_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '6' => {
           'name' => 'msg',
           'offset' => '0',
-          'type' => '4270'
+          'type' => '1443'
         },
         '7' => {
           'name' => 'payload_length',
           'offset' => '8',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_platform_event_message_req'
     },
-    '168126' => {
+    '195912' => {
       'Header' => 'platform.h',
       'Line' => '1953',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'tid',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'event_id',
-          'type' => '1006'
+          'type' => '5660'
         },
         '4' => {
           'name' => 'next_data_transfer_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '5' => {
           'name' => 'transfer_flag',
-          'type' => '121'
+          'type' => '135'
         },
         '6' => {
           'name' => 'event_class',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '7' => {
           'name' => 'event_data_size',
           'offset' => '8',
-          'type' => '1018'
+          'type' => '147'
         },
         '8' => {
           'name' => 'event_data',
           'offset' => '16',
-          'type' => '4919'
+          'type' => '1186'
         },
         '9' => {
           'name' => 'checksum',
           'offset' => '24',
-          'type' => '1018'
+          'type' => '147'
         },
         '10' => {
           'name' => 'msg',
           'offset' => '32',
-          'type' => '4270'
+          'type' => '1443'
         },
         '11' => {
           'name' => 'payload_length',
           'offset' => '40',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_poll_for_platform_event_message_resp'
     },
-    '170240' => {
+    '198026' => {
       'Header' => 'platform.h',
       'Line' => '1931',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'platform_event_status',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_platform_event_message_resp'
     },
-    '170458' => {
+    '198244' => {
       'Header' => 'platform.h',
       'Line' => '1916',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'format_version',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'transfer_operation_flag',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'data_transfer_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '5' => {
           'name' => 'event_id_to_acknowledge',
-          'type' => '12863'
+          'type' => '17516'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_poll_for_platform_event_message_req'
     },
-    '171708' => {
+    '199494' => {
       'Header' => 'platform.h',
       'Line' => '1900',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'format_version',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'tid',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'event_class',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'event_data_offset',
-          'type' => '13426'
+          'type' => '2697'
         }
       },
       'Reg' => {
@@ -6647,42 +6617,42 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_platform_event_message_req'
     },
-    '172527' => {
+    '200313' => {
       'Header' => 'platform.h',
       'Line' => '2318',
       'Param' => {
         '0' => {
           'name' => 'event_data',
-          'type' => '172718'
+          'type' => '200504'
         },
         '1' => {
           'name' => 'event_data_size',
-          'type' => '32000'
+          'type' => '36668'
         },
         '2' => {
           'name' => 'sensor_id',
-          'type' => '16179'
+          'type' => '20832'
         },
         '3' => {
           'name' => 'sensor_event_class',
-          'type' => '90459'
+          'type' => '118245'
         },
         '4' => {
           'name' => 'sensor_offset',
-          'type' => '1001'
+          'type' => '5655'
         },
         '5' => {
           'name' => 'event_state',
-          'type' => '1001'
+          'type' => '5655'
         },
         '6' => {
           'name' => 'previous_event_state',
           'offset' => '0',
-          'type' => '1001'
+          'type' => '5655'
         },
         '7' => {
           'name' => 'actual_event_data_size',
-          'type' => '130179'
+          'type' => '157965'
         }
       },
       'Reg' => {
@@ -6696,57 +6666,57 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_sensor_event_data'
     },
-    '172733' => {
+    '200519' => {
       'Header' => 'platform.h',
       'Line' => '1452',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'sensor_id',
-          'type' => '12863'
+          'type' => '17516'
         },
         '3' => {
           'name' => 'sensor_rearm',
-          'type' => '6753'
+          'type' => '11406'
         },
         '4' => {
           'name' => 'reserved',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_get_state_sensor_readings_req'
     },
-    '173638' => {
+    '201424' => {
       'Header' => 'platform.h',
       'Line' => '1820',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'comp_sensor_count',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'field',
-          'type' => '174868'
+          'type' => '202654'
         }
       },
       'Reg' => {
@@ -6756,77 +6726,77 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_state_sensor_readings_resp'
     },
-    '174873' => {
+    '202659' => {
       'Header' => 'platform.h',
       'Line' => '1800',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'sensor_id',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'sensor_rearm',
-          'type' => '2831'
+          'type' => '344'
         },
         '3' => {
           'name' => 'reserved',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_state_sensor_readings_req'
     },
-    '175111' => {
+    '202897' => {
       'Header' => 'platform.h',
       'Line' => '1472',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'comp_sensor_count',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'field',
-          'type' => '174868'
+          'type' => '202654'
         },
         '4' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_state_sensor_readings_resp'
     },
-    '175465' => {
+    '203251' => {
       'Header' => 'platform.h',
       'Line' => '1781',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -6837,33 +6807,33 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_set_numeric_effecter_value_resp'
     },
-    '175542' => {
+    '203328' => {
       'Header' => 'platform.h',
       'Line' => '1768',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'effecter_id',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'effecter_data_size',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'effecter_value',
-          'type' => '1214'
+          'type' => '5868'
         },
         '4' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '5' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
@@ -6872,105 +6842,105 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_set_numeric_effecter_value_req'
     },
-    '176014' => {
+    '203800' => {
       'Header' => 'platform.h',
       'Line' => '1343',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '3' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_set_numeric_effecter_value_resp'
     },
-    '176207' => {
+    '203993' => {
       'Header' => 'platform.h',
       'Line' => '1327',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'effecter_id',
-          'type' => '12863'
+          'type' => '17516'
         },
         '3' => {
           'name' => 'effecter_data_size',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'effecter_value',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_set_numeric_effecter_value_req'
     },
-    '179988' => {
+    '207774' => {
       'Header' => 'platform.h',
       'Line' => '1679',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'next_record_hndl',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'next_data_transfer_hndl',
-          'type' => '4924'
+          'type' => '1668'
         },
         '5' => {
           'name' => 'transfer_flag',
-          'type' => '4919'
+          'type' => '1186'
         },
         '6' => {
           'name' => 'resp_cnt',
           'offset' => '0',
-          'type' => '12863'
+          'type' => '17516'
         },
         '7' => {
           'name' => 'record_data',
           'offset' => '8',
-          'type' => '4919'
+          'type' => '1186'
         },
         '8' => {
           'name' => 'record_data_length',
           'offset' => '16',
-          'type' => '1140'
+          'type' => '164'
         },
         '9' => {
           'name' => 'transfer_crc',
           'offset' => '24',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -6979,43 +6949,43 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_pdr_resp'
     },
-    '181842' => {
+    '209628' => {
       'Header' => 'platform.h',
       'Line' => '1648',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'record_hndl',
-          'type' => '1018'
+          'type' => '147'
         },
         '2' => {
           'name' => 'data_transfer_hndl',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'transfer_op_flag',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'request_cnt',
-          'type' => '1006'
+          'type' => '5660'
         },
         '5' => {
           'name' => 'record_chg_num',
-          'type' => '1006'
+          'type' => '5660'
         },
         '6' => {
           'name' => 'msg',
           'offset' => '0',
-          'type' => '4270'
+          'type' => '1443'
         },
         '7' => {
           'name' => 'payload_length',
           'offset' => '8',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
@@ -7024,237 +6994,237 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_get_pdr_req'
     },
-    '184076' => {
+    '211862' => {
       'Header' => 'platform.h',
       'Line' => '1610',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'repository_state',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'update_time',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'oem_update_time',
-          'type' => '4919'
+          'type' => '1186'
         },
         '6' => {
           'name' => 'record_count',
           'offset' => '0',
-          'type' => '4924'
+          'type' => '1668'
         },
         '7' => {
           'name' => 'repository_size',
           'offset' => '8',
-          'type' => '4924'
+          'type' => '1668'
         },
         '8' => {
           'name' => 'largest_record_size',
           'offset' => '16',
-          'type' => '4924'
+          'type' => '1668'
         },
         '9' => {
           'name' => 'data_transfer_handle_timeout',
           'offset' => '24',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_get_pdr_repository_info_resp'
     },
-    '186135' => {
+    '213921' => {
       'Header' => 'platform.h',
       'Line' => '1586',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'repository_state',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'update_time',
-          'type' => '1214'
+          'type' => '5868'
         },
         '4' => {
           'name' => 'oem_update_time',
-          'type' => '1214'
+          'type' => '5868'
         },
         '5' => {
           'name' => 'record_count',
-          'type' => '1018'
+          'type' => '147'
         },
         '6' => {
           'name' => 'repository_size',
           'offset' => '0',
-          'type' => '1018'
+          'type' => '147'
         },
         '7' => {
           'name' => 'largest_record_size',
           'offset' => '8',
-          'type' => '1018'
+          'type' => '147'
         },
         '8' => {
           'name' => 'data_transfer_handle_timeout',
           'offset' => '16',
-          'type' => '121'
+          'type' => '135'
         },
         '9' => {
           'name' => 'msg',
           'offset' => '24',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_pdr_repository_info_resp'
     },
-    '186608' => {
+    '214394' => {
       'Header' => 'platform.h',
       'Line' => '1410',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'next_record_hndl',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'next_data_transfer_hndl',
-          'type' => '1018'
+          'type' => '147'
         },
         '4' => {
           'name' => 'transfer_flag',
-          'type' => '121'
+          'type' => '135'
         },
         '5' => {
           'name' => 'resp_cnt',
-          'type' => '1006'
+          'type' => '5660'
         },
         '6' => {
           'name' => 'record_data',
           'offset' => '0',
-          'type' => '1214'
+          'type' => '5868'
         },
         '7' => {
           'name' => 'transfer_crc',
           'offset' => '8',
-          'type' => '121'
+          'type' => '135'
         },
         '8' => {
           'name' => 'msg',
           'offset' => '16',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_pdr_resp'
     },
-    '187057' => {
+    '214843' => {
       'Header' => 'platform.h',
       'Line' => '1431',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'record_hndl',
-          'type' => '4924'
+          'type' => '1668'
         },
         '3' => {
           'name' => 'data_transfer_hndl',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'transfer_op_flag',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'request_cnt',
-          'type' => '12863'
+          'type' => '17516'
         },
         '6' => {
           'name' => 'record_chg_num',
           'offset' => '0',
-          'type' => '12863'
+          'type' => '17516'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_get_pdr_req'
     },
-    '188534' => {
+    '216320' => {
       'Header' => 'platform.h',
       'Line' => '1382',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'effecter_id',
-          'type' => '12863'
+          'type' => '17516'
         },
         '3' => {
           'name' => 'comp_effecter_count',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'field',
-          'type' => '189586'
+          'type' => '217372'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_set_state_effecter_states_req'
     },
-    '189591' => {
+    '217377' => {
       'Header' => 'platform.h',
       'Line' => '1747',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -7265,29 +7235,29 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_set_state_effecter_states_resp'
     },
-    '189666' => {
+    '217452' => {
       'Header' => 'platform.h',
       'Line' => '1728',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'effecter_id',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'comp_effecter_count',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'field',
-          'type' => '189586'
+          'type' => '217372'
         },
         '4' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Reg' => {
@@ -7296,49 +7266,49 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_set_state_effecter_states_req'
     },
-    '190010' => {
+    '217796' => {
       'Header' => 'platform.h',
       'Line' => '1360',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_set_state_effecter_states_resp'
     },
-    '190177' => {
+    '217963' => {
       'Header' => 'platform.h',
       'Line' => '710',
       'Param' => {
         '0' => {
           'name' => 'sensor',
-          'type' => '190567'
+          'type' => '218353'
         },
         '1' => {
           'name' => 'allocation_size',
-          'type' => '32000'
+          'type' => '36668'
         },
         '2' => {
           'name' => 'possible_states',
-          'type' => '190577'
+          'type' => '218363'
         },
         '3' => {
           'name' => 'possible_states_size',
-          'type' => '32000'
+          'type' => '36668'
         },
         '4' => {
           'name' => 'actual_size',
-          'type' => '130179'
+          'type' => '157965'
         }
       },
       'Reg' => {
@@ -7351,29 +7321,29 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_state_sensor_pdr'
     },
-    '190587' => {
+    '218373' => {
       'Header' => 'platform.h',
       'Line' => '950',
       'Param' => {
         '0' => {
           'name' => 'effecter',
-          'type' => '190977'
+          'type' => '218763'
         },
         '1' => {
           'name' => 'allocation_size',
-          'type' => '32000'
+          'type' => '36668'
         },
         '2' => {
           'name' => 'possible_states',
-          'type' => '190987'
+          'type' => '218773'
         },
         '3' => {
           'name' => 'possible_states_size',
-          'type' => '32000'
+          'type' => '36668'
         },
         '4' => {
           'name' => 'actual_size',
-          'type' => '130179'
+          'type' => '157965'
         }
       },
       'Reg' => {
@@ -7386,53 +7356,53 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_state_effecter_pdr'
     },
-    '194300' => {
+    '222086' => {
       'Header' => 'instance-id.h',
       'Line' => '85',
       'Param' => {
         '0' => {
           'name' => 'ctx',
-          'type' => '194480'
+          'type' => '222266'
         },
         '1' => {
           'name' => 'tid',
-          'type' => '175'
+          'type' => '4829'
         },
         '2' => {
           'name' => 'iid',
-          'type' => '187'
+          'type' => '4841'
         }
       },
       'Return' => '100',
       'ShortName' => 'pldm_instance_id_free'
     },
-    '194485' => {
+    '222271' => {
       'Header' => 'instance-id.h',
       'Line' => '68',
       'Param' => {
         '0' => {
           'name' => 'ctx',
-          'type' => '194480'
+          'type' => '222266'
         },
         '1' => {
           'name' => 'tid',
-          'type' => '175'
+          'type' => '4829'
         },
         '2' => {
           'name' => 'iid',
-          'type' => '194867'
+          'type' => '222653'
         }
       },
       'Return' => '100',
       'ShortName' => 'pldm_instance_id_alloc'
     },
-    '194872' => {
+    '222658' => {
       'Header' => 'instance-id.h',
       'Line' => '51',
       'Param' => {
         '0' => {
           'name' => 'ctx',
-          'type' => '194480'
+          'type' => '222266'
         }
       },
       'Reg' => {
@@ -7441,53 +7411,53 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_instance_db_destroy'
     },
-    '194957' => {
+    '222743' => {
       'Header' => 'instance-id.h',
       'Line' => '41',
       'Param' => {
         '0' => {
           'name' => 'ctx',
-          'type' => '195043'
+          'type' => '222829'
         }
       },
       'Return' => '100',
       'ShortName' => 'pldm_instance_db_init_default'
     },
-    '195048' => {
+    '222834' => {
       'Header' => 'instance-id.h',
       'Line' => '28',
       'Param' => {
         '0' => {
           'name' => 'ctx',
-          'type' => '195043'
+          'type' => '222829'
         },
         '1' => {
           'name' => 'dbpath',
-          'type' => '3999'
+          'type' => '8652'
         }
       },
       'Return' => '100',
       'ShortName' => 'pldm_instance_db_init'
     },
-    '195999' => {
+    '223785' => {
       'Header' => 'transport.h',
       'Line' => '53',
       'Param' => {
         '0' => {
           'name' => 'transport',
-          'type' => '196036'
+          'type' => '223822'
         },
         '1' => {
           'name' => 'tid',
-          'type' => '175'
+          'type' => '4829'
         },
         '2' => {
           'name' => 'pldm_msg',
-          'type' => '2396'
+          'type' => '1262'
         },
         '3' => {
           'name' => 'msg_len',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
@@ -7496,51 +7466,51 @@ $VAR1 = {
         '2' => 'rdx',
         '3' => 'rcx'
       },
-      'Return' => '195950',
+      'Return' => '223736',
       'ShortName' => 'pldm_transport_send_msg'
     },
-    '196046' => {
+    '223832' => {
       'Header' => 'transport.h',
       'Line' => '118',
       'Param' => {
         '0' => {
           'name' => 'transport',
-          'type' => '196036'
+          'type' => '223822'
         },
         '1' => {
           'name' => 'tid',
-          'type' => '175'
+          'type' => '4829'
         },
         '2' => {
           'name' => 'pldm_req_msg',
-          'type' => '2396'
+          'type' => '1262'
         },
         '3' => {
           'name' => 'req_msg_len',
-          'type' => '1140'
+          'type' => '164'
         },
         '4' => {
           'name' => 'pldm_resp_msg',
-          'type' => '53604'
+          'type' => '80830'
         },
         '5' => {
           'name' => 'resp_msg_len',
-          'type' => '13426'
+          'type' => '2697'
         }
       },
       'Reg' => {
         '2' => 'r14'
       },
-      'Return' => '195950',
+      'Return' => '223736',
       'ShortName' => 'pldm_transport_send_recv_msg'
     },
-    '196103' => {
+    '223889' => {
       'Header' => 'mctp-demux.h',
       'Line' => '18',
       'Param' => {
         '0' => {
           'name' => 'ctx',
-          'type' => '195994'
+          'type' => '223780'
         }
       },
       'Reg' => {
@@ -7549,25 +7519,25 @@ $VAR1 = {
       'Return' => '1',
       'ShortName' => 'pldm_transport_mctp_demux_destroy'
     },
-    '196140' => {
+    '223926' => {
       'Header' => 'transport.h',
       'Line' => '81',
       'Param' => {
         '0' => {
           'name' => 'transport',
-          'type' => '196036'
+          'type' => '223822'
         },
         '1' => {
           'name' => 'tid',
-          'type' => '196177'
+          'type' => '223963'
         },
         '2' => {
           'name' => 'pldm_msg',
-          'type' => '53604'
+          'type' => '80830'
         },
         '3' => {
           'name' => 'msg_len',
-          'type' => '13426'
+          'type' => '2697'
         }
       },
       'Reg' => {
@@ -7576,24 +7546,24 @@ $VAR1 = {
         '2' => 'rbp',
         '3' => 'rcx'
       },
-      'Return' => '195950',
+      'Return' => '223736',
       'ShortName' => 'pldm_transport_recv_msg'
     },
-    '196182' => {
+    '223968' => {
       'Header' => 'mctp-demux.h',
       'Line' => '32',
       'Param' => {
         '0' => {
           'name' => 'ctx',
-          'type' => '195994'
+          'type' => '223780'
         },
         '1' => {
           'name' => 'tid',
-          'type' => '175'
+          'type' => '4829'
         },
         '2' => {
           'name' => 'eid',
-          'type' => '195835'
+          'type' => '223621'
         }
       },
       'Reg' => {
@@ -7604,28 +7574,28 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_transport_mctp_demux_map_tid'
     },
-    '196214' => {
+    '224000' => {
       'Header' => 'mctp-demux.h',
       'Line' => '22',
       'Param' => {
         '0' => {
           'name' => 'ctx',
-          'type' => '195994'
+          'type' => '223780'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '196036',
+      'Return' => '223822',
       'ShortName' => 'pldm_transport_mctp_demux_core'
     },
-    '196258' => {
+    '224044' => {
       'Header' => 'mctp-demux.h',
       'Line' => '15',
       'Param' => {
         '0' => {
           'name' => 'ctx',
-          'type' => '196280'
+          'type' => '224066'
         }
       },
       'Reg' => {
@@ -7634,19 +7604,19 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_transport_mctp_demux_init'
     },
-    '196339' => {
+    '224125' => {
       'Header' => 'pldm.h',
       'Line' => '119',
       'Return' => '1',
       'ShortName' => 'pldm_close'
     },
-    '196383' => {
+    '224169' => {
       'Header' => 'pldm.h',
       'Line' => '75',
       'Param' => {
         '0' => {
           'name' => 'eid',
-          'type' => '195835'
+          'type' => '223621'
         },
         '1' => {
           'name' => 'mctp_fd',
@@ -7654,11 +7624,11 @@ $VAR1 = {
         },
         '2' => {
           'name' => 'pldm_req_msg',
-          'type' => '1214'
+          'type' => '5868'
         },
         '3' => {
           'name' => 'req_msg_len',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
@@ -7667,16 +7637,16 @@ $VAR1 = {
         '2' => 'rdx',
         '3' => 'rcx'
       },
-      'Return' => '195950',
+      'Return' => '223736',
       'ShortName' => 'pldm_send'
     },
-    '196802' => {
+    '224588' => {
       'Header' => 'pldm.h',
       'Line' => '57',
       'Param' => {
         '0' => {
           'name' => 'eid',
-          'type' => '195835'
+          'type' => '223621'
         },
         '1' => {
           'name' => 'mctp_fd',
@@ -7684,19 +7654,19 @@ $VAR1 = {
         },
         '2' => {
           'name' => 'pldm_req_msg',
-          'type' => '1214'
+          'type' => '5868'
         },
         '3' => {
           'name' => 'req_msg_len',
-          'type' => '1140'
+          'type' => '164'
         },
         '4' => {
           'name' => 'pldm_resp_msg',
-          'type' => '50691'
+          'type' => '76759'
         },
         '5' => {
           'name' => 'resp_msg_len',
-          'type' => '13426'
+          'type' => '2697'
         }
       },
       'Reg' => {
@@ -7707,16 +7677,16 @@ $VAR1 = {
         '4' => 'r8',
         '5' => 'r9'
       },
-      'Return' => '195950',
+      'Return' => '223736',
       'ShortName' => 'pldm_send_recv'
     },
-    '197285' => {
+    '225071' => {
       'Header' => 'pldm.h',
       'Line' => '94',
       'Param' => {
         '0' => {
           'name' => 'eid',
-          'type' => '195835'
+          'type' => '223621'
         },
         '1' => {
           'name' => 'mctp_fd',
@@ -7724,30 +7694,30 @@ $VAR1 = {
         },
         '2' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'pldm_resp_msg',
-          'type' => '50691'
+          'type' => '76759'
         },
         '4' => {
           'name' => 'resp_msg_len',
-          'type' => '13426'
+          'type' => '2697'
         }
       },
       'Reg' => {
         '3' => 'rbx'
       },
-      'Return' => '195950',
+      'Return' => '223736',
       'ShortName' => 'pldm_recv'
     },
-    '197511' => {
+    '225297' => {
       'Header' => 'pldm.h',
       'Line' => '112',
       'Param' => {
         '0' => {
           'name' => 'eid',
-          'type' => '195835'
+          'type' => '223621'
         },
         '1' => {
           'name' => 'mctp_fd',
@@ -7755,41 +7725,41 @@ $VAR1 = {
         },
         '2' => {
           'name' => 'pldm_resp_msg',
-          'type' => '50691'
+          'type' => '76759'
         },
         '3' => {
           'name' => 'resp_msg_len',
-          'type' => '13426'
+          'type' => '2697'
         }
       },
       'Reg' => {
         '2' => 'r12',
         '3' => 'r13'
       },
-      'Return' => '195950',
+      'Return' => '223736',
       'ShortName' => 'pldm_recv_any'
     },
-    '197964' => {
+    '225750' => {
       'Header' => 'pldm.h',
       'Line' => '39',
-      'Return' => '195950',
+      'Return' => '223736',
       'ShortName' => 'pldm_open'
     },
-    '200382' => {
+    '228177' => {
       'Header' => 'af-mctp.h',
       'Line' => '54',
       'Param' => {
         '0' => {
           'name' => 'transport',
-          'type' => '200538'
+          'type' => '228333'
         },
         '1' => {
           'name' => 'smctp',
-          'type' => '200543'
+          'type' => '228338'
         },
         '2' => {
           'name' => 'len',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
@@ -7799,13 +7769,13 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_transport_af_mctp_bind'
     },
-    '200548' => {
+    '228343' => {
       'Header' => 'af-mctp.h',
       'Line' => '19',
       'Param' => {
         '0' => {
           'name' => 'ctx',
-          'type' => '200538'
+          'type' => '228333'
         }
       },
       'Reg' => {
@@ -7814,13 +7784,13 @@ $VAR1 = {
       'Return' => '1',
       'ShortName' => 'pldm_transport_af_mctp_destroy'
     },
-    '200632' => {
+    '228427' => {
       'Header' => 'af-mctp.h',
       'Line' => '16',
       'Param' => {
         '0' => {
           'name' => 'ctx',
-          'type' => '200856'
+          'type' => '228651'
         }
       },
       'Reg' => {
@@ -7829,21 +7799,21 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_transport_af_mctp_init'
     },
-    '202043' => {
+    '229838' => {
       'Header' => 'af-mctp.h',
       'Line' => '37',
       'Param' => {
         '0' => {
           'name' => 'ctx',
-          'type' => '200538'
+          'type' => '228333'
         },
         '1' => {
           'name' => 'tid',
-          'type' => '175'
+          'type' => '4829'
         },
         '2' => {
           'name' => 'eid',
-          'type' => '195835'
+          'type' => '223621'
         }
       },
       'Reg' => {
@@ -7854,21 +7824,21 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_transport_af_mctp_unmap_tid'
     },
-    '202116' => {
+    '229911' => {
       'Header' => 'af-mctp.h',
       'Line' => '33',
       'Param' => {
         '0' => {
           'name' => 'ctx',
-          'type' => '200538'
+          'type' => '228333'
         },
         '1' => {
           'name' => 'tid',
-          'type' => '175'
+          'type' => '4829'
         },
         '2' => {
           'name' => 'eid',
-          'type' => '195835'
+          'type' => '223621'
         }
       },
       'Reg' => {
@@ -7879,17 +7849,17 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_transport_af_mctp_map_tid'
     },
-    '202357' => {
+    '230152' => {
       'Header' => 'af-mctp.h',
       'Line' => '28',
       'Param' => {
         '0' => {
           'name' => 't',
-          'type' => '196036'
+          'type' => '223822'
         },
         '1' => {
           'name' => 'pollfd',
-          'type' => '199034'
+          'type' => '226824'
         }
       },
       'Reg' => {
@@ -7899,36 +7869,36 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_transport_af_mctp_init_pollfd'
     },
-    '202435' => {
+    '230230' => {
       'Header' => 'af-mctp.h',
       'Line' => '23',
       'Param' => {
         '0' => {
           'name' => 'ctx',
-          'type' => '200538'
+          'type' => '228333'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '196036',
+      'Return' => '223822',
       'ShortName' => 'pldm_transport_af_mctp_core'
     },
-    '206154' => {
+    '233961' => {
       'Header' => 'mctp-demux.h',
       'Line' => '36',
       'Param' => {
         '0' => {
           'name' => 'ctx',
-          'type' => '195994'
+          'type' => '223780'
         },
         '1' => {
           'name' => 'tid',
-          'type' => '175'
+          'type' => '4829'
         },
         '2' => {
           'name' => 'eid',
-          'type' => '195835'
+          'type' => '223621'
         }
       },
       'Reg' => {
@@ -7939,17 +7909,17 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_transport_mctp_demux_unmap_tid'
     },
-    '206468' => {
+    '234275' => {
       'Header' => 'mctp-demux.h',
       'Line' => '27',
       'Param' => {
         '0' => {
           'name' => 't',
-          'type' => '196036'
+          'type' => '223822'
         },
         '1' => {
           'name' => 'pollfd',
-          'type' => '199034'
+          'type' => '226824'
         }
       },
       'Reg' => {
@@ -7959,13 +7929,13 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_transport_mctp_demux_init_pollfd'
     },
-    '214304' => {
+    '242119' => {
       'Header' => 'transport.h',
       'Line' => '31',
       'Param' => {
         '0' => {
           'name' => 'transport',
-          'type' => '196036'
+          'type' => '223822'
         },
         '1' => {
           'name' => 'timeout',
@@ -7975,68 +7945,68 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'pldm_transport_poll'
     },
-    '216503' => {
+    '244321' => {
       'Header' => 'file_io.h',
       'Line' => '912',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_new_file_with_metadata_resp'
     },
-    '216703' => {
+    '244521' => {
       'Header' => 'file_io.h',
       'Line' => '898',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'file_type',
-          'type' => '12863'
+          'type' => '17516'
         },
         '3' => {
           'name' => 'file_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'length',
-          'type' => '24846'
+          'type' => '29499'
         },
         '5' => {
           'name' => 'file_meta_data_1',
-          'type' => '4924'
+          'type' => '1668'
         },
         '6' => {
           'name' => 'file_meta_data_2',
           'offset' => '0',
-          'type' => '4924'
+          'type' => '1668'
         },
         '7' => {
           'name' => 'file_meta_data_3',
           'offset' => '8',
-          'type' => '4924'
+          'type' => '1668'
         },
         '8' => {
           'name' => 'file_meta_data_4',
           'offset' => '16',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Reg' => {
@@ -8049,21 +8019,21 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_new_file_with_metadata_req'
     },
-    '216935' => {
+    '244753' => {
       'Header' => 'file_io.h',
       'Line' => '881',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -8074,48 +8044,48 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_new_file_with_metadata_resp'
     },
-    '217036' => {
+    '244854' => {
       'Header' => 'file_io.h',
       'Line' => '866',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'file_type',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'file_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'length',
-          'type' => '16196'
+          'type' => '20849'
         },
         '4' => {
           'name' => 'file_meta_data_1',
-          'type' => '1018'
+          'type' => '147'
         },
         '5' => {
           'name' => 'file_meta_data_2',
-          'type' => '1018'
+          'type' => '147'
         },
         '6' => {
           'name' => 'file_meta_data_3',
           'offset' => '0',
-          'type' => '1018'
+          'type' => '147'
         },
         '7' => {
           'name' => 'file_meta_data_4',
           'offset' => '8',
-          'type' => '1018'
+          'type' => '147'
         },
         '8' => {
           'name' => 'msg',
           'offset' => '16',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Reg' => {
@@ -8124,68 +8094,68 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_new_file_with_metadata_req'
     },
-    '217333' => {
+    '245151' => {
       'Header' => 'file_io.h',
       'Line' => '824',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_file_ack_with_meta_data_resp'
     },
-    '217528' => {
+    '245346' => {
       'Header' => 'file_io.h',
       'Line' => '811',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'file_type',
-          'type' => '12863'
+          'type' => '17516'
         },
         '3' => {
           'name' => 'file_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'file_status',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'file_meta_data_1',
-          'type' => '4924'
+          'type' => '1668'
         },
         '6' => {
           'name' => 'file_meta_data_2',
           'offset' => '0',
-          'type' => '4924'
+          'type' => '1668'
         },
         '7' => {
           'name' => 'file_meta_data_3',
           'offset' => '8',
-          'type' => '4924'
+          'type' => '1668'
         },
         '8' => {
           'name' => 'file_meta_data_4',
           'offset' => '16',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Reg' => {
@@ -8198,21 +8168,21 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_file_ack_with_meta_data_req'
     },
-    '217740' => {
+    '245558' => {
       'Header' => 'file_io.h',
       'Line' => '794',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -8223,48 +8193,48 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_file_ack_with_meta_data_resp'
     },
-    '217836' => {
+    '245654' => {
       'Header' => 'file_io.h',
       'Line' => '781',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'file_type',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'file_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'file_status',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'file_meta_data_1',
-          'type' => '1018'
+          'type' => '147'
         },
         '5' => {
           'name' => 'file_meta_data_2',
-          'type' => '1018'
+          'type' => '147'
         },
         '6' => {
           'name' => 'file_meta_data_3',
           'offset' => '0',
-          'type' => '1018'
+          'type' => '147'
         },
         '7' => {
           'name' => 'file_meta_data_4',
           'offset' => '8',
-          'type' => '1018'
+          'type' => '147'
         },
         '8' => {
           'name' => 'msg',
           'offset' => '16',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Reg' => {
@@ -8273,21 +8243,21 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_file_ack_with_meta_data_req'
     },
-    '218133' => {
+    '245951' => {
       'Header' => 'file_io.h',
       'Line' => '741',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -8298,77 +8268,77 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_file_ack_resp'
     },
-    '218234' => {
+    '246052' => {
       'Header' => 'file_io.h',
       'Line' => '730',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'file_type',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'file_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'file_status',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_file_ack_req'
     },
-    '218469' => {
+    '246287' => {
       'Header' => 'file_io.h',
       'Line' => '718',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_file_ack_resp'
     },
-    '218659' => {
+    '246477' => {
       'Header' => 'file_io.h',
       'Line' => '706',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'file_type',
-          'type' => '12863'
+          'type' => '17516'
         },
         '3' => {
           'name' => 'file_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'file_status',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -8380,25 +8350,25 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_file_ack_req'
     },
-    '218801' => {
+    '246619' => {
       'Header' => 'file_io.h',
       'Line' => '675',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'length',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Reg' => {
@@ -8410,98 +8380,98 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_rw_file_by_type_resp'
     },
-    '218916' => {
+    '246734' => {
       'Header' => 'file_io.h',
       'Line' => '661',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'command',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'file_type',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'file_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '4' => {
           'name' => 'offset',
-          'type' => '1018'
+          'type' => '147'
         },
         '5' => {
           'name' => 'length',
-          'type' => '1018'
+          'type' => '147'
         },
         '6' => {
           'name' => 'msg',
           'offset' => '0',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_rw_file_by_type_req'
     },
-    '219186' => {
+    '247004' => {
       'Header' => 'file_io.h',
       'Line' => '644',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'command',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'length',
-          'type' => '1018'
+          'type' => '147'
         },
         '4' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_rw_file_by_type_resp'
     },
-    '219416' => {
+    '247234' => {
       'Header' => 'file_io.h',
       'Line' => '626',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'file_type',
-          'type' => '12863'
+          'type' => '17516'
         },
         '3' => {
           'name' => 'file_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'offset',
-          'type' => '4924'
+          'type' => '1668'
         },
         '5' => {
           'name' => 'length',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Reg' => {
@@ -8514,21 +8484,21 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_rw_file_by_type_req'
     },
-    '219578' => {
+    '247396' => {
       'Header' => 'file_io.h',
       'Line' => '590',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -8539,77 +8509,77 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_new_file_resp'
     },
-    '219679' => {
+    '247497' => {
       'Header' => 'file_io.h',
       'Line' => '579',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'file_type',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'file_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'length',
-          'type' => '16196'
+          'type' => '20849'
         },
         '4' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_new_file_req'
     },
-    '219914' => {
+    '247732' => {
       'Header' => 'file_io.h',
       'Line' => '567',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_new_file_resp'
     },
-    '220104' => {
+    '247922' => {
       'Header' => 'file_io.h',
       'Line' => '555',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'file_type',
-          'type' => '12863'
+          'type' => '17516'
         },
         '3' => {
           'name' => 'file_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'length',
-          'type' => '24846'
+          'type' => '29499'
         }
       },
       'Reg' => {
@@ -8621,25 +8591,25 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_new_file_req'
     },
-    '220246' => {
+    '248064' => {
       'Header' => 'file_io.h',
       'Line' => '523',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'length',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Reg' => {
@@ -8651,108 +8621,108 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_rw_file_by_type_memory_resp'
     },
-    '220361' => {
+    '248179' => {
       'Header' => 'file_io.h',
       'Line' => '509',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'command',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'file_type',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'file_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '4' => {
           'name' => 'offset',
-          'type' => '1018'
+          'type' => '147'
         },
         '5' => {
           'name' => 'length',
-          'type' => '1018'
+          'type' => '147'
         },
         '6' => {
           'name' => 'address',
           'offset' => '0',
-          'type' => '16196'
+          'type' => '20849'
         },
         '7' => {
           'name' => 'msg',
           'offset' => '8',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_rw_file_by_type_memory_req'
     },
-    '220646' => {
+    '248464' => {
       'Header' => 'file_io.h',
       'Line' => '491',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'command',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'length',
-          'type' => '1018'
+          'type' => '147'
         },
         '4' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_rw_file_by_type_memory_resp'
     },
-    '220876' => {
+    '248694' => {
       'Header' => 'file_io.h',
       'Line' => '473',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'file_type',
-          'type' => '12863'
+          'type' => '17516'
         },
         '3' => {
           'name' => 'file_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'offset',
-          'type' => '4924'
+          'type' => '1668'
         },
         '5' => {
           'name' => 'length',
-          'type' => '4924'
+          'type' => '1668'
         },
         '6' => {
           'name' => 'address',
           'offset' => '0',
-          'type' => '24846'
+          'type' => '29499'
         }
       },
       'Reg' => {
@@ -8765,49 +8735,49 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_rw_file_by_type_memory_req'
     },
-    '221053' => {
+    '248871' => {
       'Header' => 'file_io.h',
       'Line' => '435',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'length',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_write_file_resp'
     },
-    '221268' => {
+    '249086' => {
       'Header' => 'file_io.h',
       'Line' => '422',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'length',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Reg' => {
@@ -8819,61 +8789,61 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_write_file_resp'
     },
-    '221378' => {
+    '249196' => {
       'Header' => 'file_io.h',
       'Line' => '410',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'file_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '2' => {
           'name' => 'offset',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'length',
-          'type' => '1018'
+          'type' => '147'
         },
         '4' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_write_file_req'
     },
-    '221613' => {
+    '249431' => {
       'Header' => 'file_io.h',
       'Line' => '391',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'file_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '3' => {
           'name' => 'offset',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'length',
-          'type' => '4924'
+          'type' => '1668'
         },
         '5' => {
           'name' => 'file_data_offset',
-          'type' => '13426'
+          'type' => '2697'
         }
       },
       'Reg' => {
@@ -8885,53 +8855,53 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_write_file_req'
     },
-    '221768' => {
+    '249586' => {
       'Header' => 'file_io.h',
       'Line' => '377',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'length',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_read_file_resp'
     },
-    '221983' => {
+    '249801' => {
       'Header' => 'file_io.h',
       'Line' => '359',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'length',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'file_data_offset',
-          'type' => '13426'
+          'type' => '2697'
         }
       },
       'Reg' => {
@@ -8943,57 +8913,57 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_read_file_resp'
     },
-    '222119' => {
+    '249937' => {
       'Header' => 'file_io.h',
       'Line' => '344',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'file_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '2' => {
           'name' => 'offset',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'length',
-          'type' => '1018'
+          'type' => '147'
         },
         '4' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_read_file_req'
     },
-    '222354' => {
+    '250172' => {
       'Header' => 'file_io.h',
       'Line' => '330',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'file_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '3' => {
           'name' => 'offset',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'length',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Reg' => {
@@ -9005,38 +8975,38 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_read_file_req'
     },
-    '222490' => {
+    '250308' => {
       'Header' => 'file_io.h',
       'Line' => '274',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'next_transfer_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'transfer_flag',
-          'type' => '4919'
+          'type' => '1186'
         },
         '5' => {
           'name' => 'file_table_data_start_offset',
-          'type' => '4919'
+          'type' => '1186'
         },
         '6' => {
           'name' => 'file_table_length',
           'offset' => '0',
-          'type' => '13426'
+          'type' => '2697'
         }
       },
       'Reg' => {
@@ -9049,66 +9019,66 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_file_table_resp'
     },
-    '222664' => {
+    '250482' => {
       'Header' => 'file_io.h',
       'Line' => '258',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'transfer_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '2' => {
           'name' => 'transfer_opflag',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'table_type',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_file_table_req'
     },
-    '222891' => {
+    '250709' => {
       'Header' => 'file_io.h',
       'Line' => '244',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'next_transfer_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'transfer_flag',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'table_data',
-          'type' => '1214'
+          'type' => '5868'
         },
         '5' => {
           'name' => 'table_size',
-          'type' => '1140'
+          'type' => '164'
         },
         '6' => {
           'name' => 'msg',
           'offset' => '0',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Reg' => {
@@ -9117,29 +9087,29 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_get_file_table_resp'
     },
-    '223249' => {
+    '251067' => {
       'Header' => 'file_io.h',
       'Line' => '227',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'transfer_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '3' => {
           'name' => 'transfer_opflag',
-          'type' => '4919'
+          'type' => '1186'
         },
         '4' => {
           'name' => 'table_type',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -9151,25 +9121,25 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_file_table_req'
     },
-    '223384' => {
+    '251202' => {
       'Header' => 'file_io.h',
       'Line' => '183',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'length',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Reg' => {
@@ -9181,38 +9151,38 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_rw_file_memory_resp'
     },
-    '223493' => {
+    '251311' => {
       'Header' => 'file_io.h',
       'Line' => '169',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'command',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'file_handle',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'offset',
-          'type' => '1018'
+          'type' => '147'
         },
         '4' => {
           'name' => 'length',
-          'type' => '1018'
+          'type' => '147'
         },
         '5' => {
           'name' => 'address',
-          'type' => '16196'
+          'type' => '20849'
         },
         '6' => {
           'name' => 'msg',
           'offset' => '0',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Reg' => {
@@ -9221,61 +9191,61 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_rw_file_memory_req'
     },
-    '223752' => {
+    '251570' => {
       'Header' => 'file_io.h',
       'Line' => '152',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'command',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'length',
-          'type' => '1018'
+          'type' => '147'
         },
         '4' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_rw_file_memory_resp'
     },
-    '223973' => {
+    '251791' => {
       'Header' => 'file_io.h',
       'Line' => '136',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'file_handle',
-          'type' => '4924'
+          'type' => '1668'
         },
         '3' => {
           'name' => 'offset',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'length',
-          'type' => '4924'
+          'type' => '1668'
         },
         '5' => {
           'name' => 'address',
-          'type' => '24846'
+          'type' => '29499'
         }
       },
       'Reg' => {
@@ -9288,33 +9258,33 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_rw_file_memory_req'
     },
-    '225022' => {
+    '252840' => {
       'Header' => 'host.h',
       'Line' => '101',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'completion_code',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'rack_entry',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'pri_cec_node',
-          'type' => '1018'
+          'type' => '147'
         },
         '4' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '5' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
@@ -9323,21 +9293,21 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_get_alert_status_resp'
     },
-    '225270' => {
+    '253088' => {
       'Header' => 'host.h',
       'Line' => '86',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'version_id',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -9348,29 +9318,29 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_alert_status_req'
     },
-    '225353' => {
+    '253171' => {
       'Header' => 'host.h',
       'Line' => '70',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'completion_code',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'rack_entry',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'pri_cec_node',
-          'type' => '4924'
+          'type' => '1668'
         }
       },
       'Reg' => {
@@ -9382,90 +9352,90 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_get_alert_status_resp'
     },
-    '225492' => {
+    '253310' => {
       'Header' => 'host.h',
       'Line' => '52',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'version_id',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'msg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '3' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_get_alert_status_req'
     },
-    '226710' => {
+    '254528' => {
       'Header' => 'platform.h',
       'Line' => '47',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'format_version',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'tid',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'num_handles',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'list_of_handles',
-          'type' => '1214'
+          'type' => '5868'
         },
         '5' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '6' => {
           'name' => 'msg',
           'offset' => '0',
-          'type' => '4270'
+          'type' => '1443'
         }
       },
       'Return' => '100',
       'ShortName' => 'encode_bios_attribute_update_event_req'
     },
-    '228560' => {
+    '256378' => {
       'Header' => 'file_io.h',
       'Line' => '160',
       'Param' => {
         '0' => {
           'name' => 'instance_id',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'resp',
-          'type' => '230271'
+          'type' => '258089'
         },
         '2' => {
           'name' => 'resp_len',
-          'type' => '1140'
+          'type' => '164'
         },
         '3' => {
           'name' => 'responseMsg',
-          'type' => '4270'
+          'type' => '1443'
         },
         '4' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Reg' => {
@@ -9474,64 +9444,64 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'encode_oem_meta_file_io_read_resp'
     },
-    '230286' => {
+    '258104' => {
       'Header' => 'file_io.h',
       'Line' => '147',
       'Param' => {
         '0' => {
           'name' => 'resp',
-          'type' => '230271'
+          'type' => '258089'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '2634',
+      'Return' => '126',
       'ShortName' => 'pldm_oem_meta_file_io_read_resp_data'
     },
-    '230334' => {
+    '258152' => {
       'Header' => 'file_io.h',
       'Line' => '137',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'req',
-          'type' => '231400'
+          'type' => '259218'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_oem_meta_file_io_read_req'
     },
-    '231405' => {
+    '259223' => {
       'Header' => 'file_io.h',
       'Line' => '126',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'file_handle',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'length',
-          'type' => '4924'
+          'type' => '1668'
         },
         '4' => {
           'name' => 'data',
-          'type' => '4919'
+          'type' => '1186'
         }
       },
       'Reg' => {
@@ -9544,43 +9514,43 @@ $VAR1 = {
       'Return' => '100',
       'ShortName' => 'decode_oem_meta_file_io_req'
     },
-    '231841' => {
+    '259659' => {
       'Header' => 'file_io.h',
       'Line' => '113',
       'Param' => {
         '0' => {
           'name' => 'msg',
-          'type' => '4914'
+          'type' => '1522'
         },
         '1' => {
           'name' => 'payload_length',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'req',
-          'type' => '231836'
+          'type' => '259654'
         },
         '3' => {
           'name' => 'req_length',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Return' => '100',
       'ShortName' => 'decode_oem_meta_file_io_write_req'
     },
-    '232806' => {
+    '260624' => {
       'Header' => 'file_io.h',
       'Line' => '102',
       'Param' => {
         '0' => {
           'name' => 'req',
-          'type' => '231836'
+          'type' => '259654'
         }
       },
       'Reg' => {
         '0' => 'rdi'
       },
-      'Return' => '2634',
+      'Return' => '126',
       'ShortName' => 'pldm_oem_meta_file_io_write_req_data'
     }
   },
@@ -9986,16 +9956,31 @@ $VAR1 = {
       'Type' => 'Intrinsic'
     },
     '107' => {
+      'BaseType' => '60',
+      'Header' => 'types.h',
+      'Line' => '42',
+      'Name' => '__uint32_t',
+      'PrivateABI' => 1,
+      'Size' => '4',
+      'Type' => 'Typedef'
+    },
+    '119' => {
       'Name' => 'long',
       'Size' => '8',
       'Type' => 'Intrinsic'
     },
-    '114' => {
+    '126' => {
+      'BaseType' => '1',
+      'Name' => 'void*',
+      'Size' => '8',
+      'Type' => 'Pointer'
+    },
+    '128' => {
       'Name' => 'char',
       'Size' => '1',
       'Type' => 'Intrinsic'
     },
-    '121' => {
+    '135' => {
       'BaseType' => '81',
       'Header' => 'stdint-uintn.h',
       'Line' => '24',
@@ -10004,55 +9989,347 @@ $VAR1 = {
       'Size' => '1',
       'Type' => 'Typedef'
     },
-    '133' => {
+    '147' => {
+      'BaseType' => '107',
+      'Header' => 'stdint-uintn.h',
+      'Line' => '26',
+      'Name' => 'uint32_t',
+      'PrivateABI' => 1,
+      'Size' => '4',
+      'Type' => 'Typedef'
+    },
+    '159' => {
+      'BaseType' => '147',
+      'Name' => 'uint32_t const',
+      'Size' => '4',
+      'Type' => 'Const'
+    },
+    '164' => {
+      'BaseType' => '67',
+      'Header' => 'stddef.h',
+      'Line' => '214',
+      'Name' => 'size_t',
+      'PrivateABI' => 1,
+      'Size' => '8',
+      'Type' => 'Typedef'
+    },
+    '190' => {
+      'Header' => 'pldm_types.h',
+      'Line' => '9',
+      'Name' => 'anon-struct-pldm_types.h-9',
+      'Size' => '1',
+      'Type' => 'Struct'
+    },
+    '344' => {
+      'Header' => 'pldm_types.h',
+      'Line' => '19',
+      'Memb' => {
+        '0' => {
+          'name' => 'byte',
+          'offset' => '0',
+          'type' => '135'
+        },
+        '1' => {
+          'name' => 'bits',
+          'offset' => '0',
+          'type' => '190'
+        }
+      },
+      'Name' => 'union bitfield8_t',
+      'Size' => '1',
+      'Type' => 'Union'
+    },
+    '356' => {
+      'BaseType' => '344',
+      'Name' => 'bitfield8_t const',
+      'Size' => '1',
+      'Type' => 'Const'
+    },
+    '361' => {
+      'Header' => 'pldm_types.h',
+      'Line' => '25',
+      'Memb' => {
+        '0' => {
+          'name' => 'alpha',
+          'offset' => '0',
+          'type' => '135'
+        },
+        '1' => {
+          'name' => 'update',
+          'offset' => '1',
+          'type' => '135'
+        },
+        '2' => {
+          'name' => 'minor',
+          'offset' => '2',
+          'type' => '135'
+        },
+        '3' => {
+          'name' => 'major',
+          'offset' => '3',
+          'type' => '135'
+        }
+      },
+      'Name' => 'struct pldm_version',
+      'Size' => '4',
+      'Type' => 'Struct'
+    },
+    '427' => {
+      'BaseType' => '361',
+      'Header' => 'pldm_types.h',
+      'Line' => '30',
+      'Name' => 'ver32_t',
+      'Size' => '4',
+      'Type' => 'Typedef'
+    },
+    '439' => {
+      'BaseType' => '427',
+      'Name' => 'ver32_t const',
+      'Size' => '4',
+      'Type' => 'Const'
+    },
+    '444' => {
       'Name' => 'float',
       'Size' => '4',
       'Type' => 'Intrinsic'
     },
-    '175' => {
-      'BaseType' => '121',
+    '789' => {
+      'Header' => 'base.h',
+      'Line' => '97',
+      'Memb' => {
+        '0' => {
+          'name' => 'PLDM_RESPONSE',
+          'value' => '0'
+        },
+        '1' => {
+          'name' => 'PLDM_REQUEST',
+          'value' => '1'
+        },
+        '2' => {
+          'name' => 'PLDM_RESERVED',
+          'value' => '2'
+        },
+        '3' => {
+          'name' => 'PLDM_ASYNC_REQUEST_NOTIFY',
+          'value' => '3'
+        }
+      },
+      'Name' => 'enum MessageType',
+      'Size' => '4',
+      'Type' => 'Enum'
+    },
+    '801' => {
+      'Header' => 'base.h',
+      'Line' => '145',
+      'Memb' => {
+        '0' => {
+          'name' => 'command',
+          'offset' => '2',
+          'type' => '135'
+        }
+      },
+      'Name' => 'struct pldm_msg_hdr',
+      'Size' => '3',
+      'Type' => 'Struct'
+    },
+    '912' => {
+      'BaseType' => '801',
+      'Name' => 'struct pldm_msg_hdr const',
+      'Size' => '3',
+      'Type' => 'Const'
+    },
+    '917' => {
+      'Header' => 'base.h',
+      'Line' => '178',
+      'Memb' => {
+        '0' => {
+          'name' => 'hdr',
+          'offset' => '0',
+          'type' => '801'
+        },
+        '1' => {
+          'name' => 'payload',
+          'offset' => '3',
+          'type' => '962'
+        }
+      },
+      'Name' => 'struct pldm_msg',
+      'Size' => '4',
+      'Type' => 'Struct'
+    },
+    '957' => {
+      'BaseType' => '917',
+      'Name' => 'struct pldm_msg const',
+      'Size' => '4',
+      'Type' => 'Const'
+    },
+    '962' => {
+      'BaseType' => '135',
+      'Name' => 'uint8_t[1]',
+      'Size' => '1',
+      'Type' => 'Array'
+    },
+    '978' => {
+      'Header' => 'base.h',
+      'Line' => '245',
+      'Memb' => {
+        '0' => {
+          'name' => 'msg_type',
+          'offset' => '0',
+          'type' => '789'
+        },
+        '1' => {
+          'name' => 'instance',
+          'offset' => '4',
+          'type' => '135'
+        },
+        '2' => {
+          'name' => 'pldm_type',
+          'offset' => '5',
+          'type' => '135'
+        },
+        '3' => {
+          'name' => 'command',
+          'offset' => '6',
+          'type' => '135'
+        },
+        '4' => {
+          'name' => 'completion_code',
+          'offset' => '7',
+          'type' => '135'
+        }
+      },
+      'Name' => 'struct pldm_header_info',
+      'Size' => '8',
+      'Type' => 'Struct'
+    },
+    '1057' => {
+      'BaseType' => '978',
+      'Name' => 'struct pldm_header_info const',
+      'Size' => '8',
+      'Type' => 'Const'
+    },
+    '1186' => {
+      'BaseType' => '135',
+      'Name' => 'uint8_t*',
+      'Size' => '8',
+      'Type' => 'Pointer'
+    },
+    '1262' => {
+      'BaseType' => '1267',
+      'Name' => 'void const*',
+      'Size' => '8',
+      'Type' => 'Pointer'
+    },
+    '1267' => {
+      'BaseType' => '1',
+      'Name' => 'void const',
+      'Type' => 'Const'
+    },
+    '1268' => {
+      'BaseType' => '356',
+      'Name' => 'bitfield8_t const*',
+      'Size' => '8',
+      'Type' => 'Pointer'
+    },
+    '1443' => {
+      'BaseType' => '917',
+      'Name' => 'struct pldm_msg*',
+      'Size' => '8',
+      'Type' => 'Pointer'
+    },
+    '1522' => {
+      'BaseType' => '957',
+      'Name' => 'struct pldm_msg const*',
+      'Size' => '8',
+      'Type' => 'Pointer'
+    },
+    '1527' => {
+      'BaseType' => '427',
+      'Name' => 'ver32_t*',
+      'Size' => '8',
+      'Type' => 'Pointer'
+    },
+    '1621' => {
+      'BaseType' => '439',
+      'Name' => 'ver32_t const*',
+      'Size' => '8',
+      'Type' => 'Pointer'
+    },
+    '1668' => {
+      'BaseType' => '147',
+      'Name' => 'uint32_t*',
+      'Size' => '8',
+      'Type' => 'Pointer'
+    },
+    '1737' => {
+      'BaseType' => '912',
+      'Name' => 'struct pldm_msg_hdr const*',
+      'Size' => '8',
+      'Type' => 'Pointer'
+    },
+    '1742' => {
+      'BaseType' => '978',
+      'Name' => 'struct pldm_header_info*',
+      'Size' => '8',
+      'Type' => 'Pointer'
+    },
+    '2697' => {
+      'BaseType' => '164',
+      'Name' => 'size_t*',
+      'Size' => '8',
+      'Type' => 'Pointer'
+    },
+    '3157' => {
+      'BaseType' => '1057',
+      'Name' => 'struct pldm_header_info const*',
+      'Size' => '8',
+      'Type' => 'Pointer'
+    },
+    '4829' => {
+      'BaseType' => '135',
       'Header' => 'base.h',
       'Line' => '17',
       'Name' => 'pldm_tid_t',
       'Size' => '1',
       'Type' => 'Typedef'
     },
-    '187' => {
-      'BaseType' => '121',
+    '4841' => {
+      'BaseType' => '135',
       'Header' => 'instance-id.h',
       'Line' => '13',
       'Name' => 'pldm_instance_id_t',
       'Size' => '1',
       'Type' => 'Typedef'
     },
-    '199' => {
+    '4853' => {
       'Header' => 'responder.h',
       'Line' => '10',
       'Memb' => {
         '0' => {
           'name' => 'tid',
           'offset' => '0',
-          'type' => '175'
+          'type' => '4829'
         },
         '1' => {
           'name' => 'instance_id',
           'offset' => '1',
-          'type' => '187'
+          'type' => '4841'
         },
         '2' => {
           'name' => 'type',
           'offset' => '2',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'command',
           'offset' => '3',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'next',
           'offset' => '8',
-          'type' => '279'
+          'type' => '4933'
         }
       },
       'Name' => 'struct pldm_responder_cookie',
@@ -10060,13 +10337,13 @@ $VAR1 = {
       'Size' => '16',
       'Type' => 'Struct'
     },
-    '279' => {
-      'BaseType' => '199',
+    '4933' => {
+      'BaseType' => '4853',
       'Name' => 'struct pldm_responder_cookie*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '284' => {
+    '4938' => {
       'Header' => 'pldm.h',
       'Line' => '15',
       'Memb' => {
@@ -10131,12 +10408,12 @@ $VAR1 = {
       'Size' => '4',
       'Type' => 'Enum'
     },
-    '805' => {
+    '5459' => {
       'Name' => '_Bool',
       'Size' => '1',
       'Type' => 'Intrinsic'
     },
-    '927' => {
+    '5581' => {
       'BaseType' => '53',
       'Header' => 'types.h',
       'Line' => '40',
@@ -10145,17 +10422,8 @@ $VAR1 = {
       'Size' => '2',
       'Type' => 'Typedef'
     },
-    '946' => {
-      'BaseType' => '60',
-      'Header' => 'types.h',
-      'Line' => '42',
-      'Name' => '__uint32_t',
-      'PrivateABI' => 1,
-      'Size' => '4',
-      'Type' => 'Typedef'
-    },
-    '965' => {
-      'BaseType' => '107',
+    '5619' => {
+      'BaseType' => '119',
       'Header' => 'types.h',
       'Line' => '194',
       'Name' => '__ssize_t',
@@ -10163,20 +10431,20 @@ $VAR1 = {
       'Size' => '8',
       'Type' => 'Typedef'
     },
-    '977' => {
-      'BaseType' => '114',
+    '5631' => {
+      'BaseType' => '128',
       'Name' => 'char*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '1001' => {
-      'BaseType' => '121',
+    '5655' => {
+      'BaseType' => '135',
       'Name' => 'uint8_t const',
       'Size' => '1',
       'Type' => 'Const'
     },
-    '1006' => {
-      'BaseType' => '927',
+    '5660' => {
+      'BaseType' => '5581',
       'Header' => 'stdint-uintn.h',
       'Line' => '25',
       'Name' => 'uint16_t',
@@ -10184,69 +10452,8 @@ $VAR1 = {
       'Size' => '2',
       'Type' => 'Typedef'
     },
-    '1018' => {
-      'BaseType' => '946',
-      'Header' => 'stdint-uintn.h',
-      'Line' => '26',
-      'Name' => 'uint32_t',
-      'PrivateABI' => 1,
-      'Size' => '4',
-      'Type' => 'Typedef'
-    },
-    '1030' => {
-      'Header' => 'pldm_types.h',
-      'Line' => '25',
-      'Memb' => {
-        '0' => {
-          'name' => 'alpha',
-          'offset' => '0',
-          'type' => '121'
-        },
-        '1' => {
-          'name' => 'update',
-          'offset' => '1',
-          'type' => '121'
-        },
-        '2' => {
-          'name' => 'minor',
-          'offset' => '2',
-          'type' => '121'
-        },
-        '3' => {
-          'name' => 'major',
-          'offset' => '3',
-          'type' => '121'
-        }
-      },
-      'Name' => 'struct pldm_version',
-      'Size' => '4',
-      'Type' => 'Struct'
-    },
-    '1088' => {
-      'BaseType' => '1030',
-      'Header' => 'pldm_types.h',
-      'Line' => '30',
-      'Name' => 'ver32_t',
-      'Size' => '4',
-      'Type' => 'Typedef'
-    },
-    '1100' => {
-      'BaseType' => '1088',
-      'Name' => 'ver32_t const',
-      'Size' => '4',
-      'Type' => 'Const'
-    },
-    '1140' => {
-      'BaseType' => '67',
-      'Header' => 'stddef.h',
-      'Line' => '214',
-      'Name' => 'size_t',
-      'PrivateABI' => 1,
-      'Size' => '8',
-      'Type' => 'Typedef'
-    },
-    '1202' => {
-      'BaseType' => '965',
+    '5856' => {
+      'BaseType' => '5619',
       'Header' => 'types.h',
       'Line' => '108',
       'Name' => 'ssize_t',
@@ -10254,299 +10461,68 @@ $VAR1 = {
       'Size' => '8',
       'Type' => 'Typedef'
     },
-    '1214' => {
-      'BaseType' => '1001',
+    '5868' => {
+      'BaseType' => '5655',
       'Name' => 'uint8_t const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '2283' => {
-      'BaseType' => '1100',
-      'Name' => 'ver32_t const*',
-      'Size' => '8',
-      'Type' => 'Pointer'
-    },
-    '2396' => {
-      'BaseType' => '2401',
-      'Name' => 'void const*',
-      'Size' => '8',
-      'Type' => 'Pointer'
-    },
-    '2401' => {
-      'BaseType' => '1',
-      'Name' => 'void const',
-      'Type' => 'Const'
-    },
-    '2634' => {
-      'BaseType' => '1',
-      'Name' => 'void*',
-      'Size' => '8',
-      'Type' => 'Pointer'
-    },
-    '2648' => {
-      'BaseType' => '114',
+    '7302' => {
+      'BaseType' => '128',
       'Name' => 'char const',
       'Size' => '1',
       'Type' => 'Const'
     },
-    '2677' => {
-      'Header' => 'pldm_types.h',
-      'Line' => '9',
-      'Name' => 'anon-struct-pldm_types.h-9',
-      'Size' => '1',
-      'Type' => 'Struct'
-    },
-    '2831' => {
-      'Header' => 'pldm_types.h',
-      'Line' => '19',
-      'Memb' => {
-        '0' => {
-          'name' => 'byte',
-          'offset' => '0',
-          'type' => '121'
-        },
-        '1' => {
-          'name' => 'bits',
-          'offset' => '0',
-          'type' => '2677'
-        }
-      },
-      'Name' => 'union bitfield8_t',
-      'Size' => '1',
-      'Type' => 'Union'
-    },
-    '2843' => {
-      'BaseType' => '2831',
-      'Name' => 'bitfield8_t const',
-      'Size' => '1',
-      'Type' => 'Const'
-    },
-    '3270' => {
-      'Header' => 'base.h',
-      'Line' => '97',
-      'Memb' => {
-        '0' => {
-          'name' => 'PLDM_RESPONSE',
-          'value' => '0'
-        },
-        '1' => {
-          'name' => 'PLDM_REQUEST',
-          'value' => '1'
-        },
-        '2' => {
-          'name' => 'PLDM_RESERVED',
-          'value' => '2'
-        },
-        '3' => {
-          'name' => 'PLDM_ASYNC_REQUEST_NOTIFY',
-          'value' => '3'
-        }
-      },
-      'Name' => 'enum MessageType',
-      'Size' => '4',
-      'Type' => 'Enum'
-    },
-    '3282' => {
-      'Header' => 'base.h',
-      'Line' => '143',
-      'Memb' => {
-        '0' => {
-          'name' => 'command',
-          'offset' => '2',
-          'type' => '121'
-        }
-      },
-      'Name' => 'struct pldm_msg_hdr',
-      'Size' => '3',
-      'Type' => 'Struct'
-    },
-    '3393' => {
-      'BaseType' => '3282',
-      'Name' => 'struct pldm_msg_hdr const',
-      'Size' => '3',
-      'Type' => 'Const'
-    },
-    '3398' => {
-      'Header' => 'base.h',
-      'Line' => '176',
-      'Memb' => {
-        '0' => {
-          'name' => 'hdr',
-          'offset' => '0',
-          'type' => '3282'
-        },
-        '1' => {
-          'name' => 'payload',
-          'offset' => '3',
-          'type' => '3443'
-        }
-      },
-      'Name' => 'struct pldm_msg',
-      'Size' => '4',
-      'Type' => 'Struct'
-    },
-    '3438' => {
-      'BaseType' => '3398',
-      'Name' => 'struct pldm_msg const',
-      'Size' => '4',
-      'Type' => 'Const'
-    },
-    '3443' => {
-      'BaseType' => '121',
-      'Name' => 'uint8_t[1]',
-      'Size' => '1',
-      'Type' => 'Array'
-    },
-    '3459' => {
-      'Header' => 'base.h',
-      'Line' => '243',
-      'Memb' => {
-        '0' => {
-          'name' => 'msg_type',
-          'offset' => '0',
-          'type' => '3270'
-        },
-        '1' => {
-          'name' => 'instance',
-          'offset' => '4',
-          'type' => '121'
-        },
-        '2' => {
-          'name' => 'pldm_type',
-          'offset' => '5',
-          'type' => '121'
-        },
-        '3' => {
-          'name' => 'command',
-          'offset' => '6',
-          'type' => '121'
-        },
-        '4' => {
-          'name' => 'completion_code',
-          'offset' => '7',
-          'type' => '121'
-        }
-      },
-      'Name' => 'struct pldm_header_info',
-      'Size' => '8',
-      'Type' => 'Struct'
-    },
-    '3538' => {
-      'BaseType' => '3459',
-      'Name' => 'struct pldm_header_info const',
-      'Size' => '8',
-      'Type' => 'Const'
-    },
-    '3999' => {
-      'BaseType' => '2648',
+    '8652' => {
+      'BaseType' => '7302',
       'Name' => 'char const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '4270' => {
-      'BaseType' => '3398',
-      'Name' => 'struct pldm_msg*',
-      'Size' => '8',
-      'Type' => 'Pointer'
-    },
-    '4914' => {
-      'BaseType' => '3438',
-      'Name' => 'struct pldm_msg const*',
-      'Size' => '8',
-      'Type' => 'Pointer'
-    },
-    '4919' => {
-      'BaseType' => '121',
-      'Name' => 'uint8_t*',
-      'Size' => '8',
-      'Type' => 'Pointer'
-    },
-    '4924' => {
-      'BaseType' => '1018',
-      'Name' => 'uint32_t*',
-      'Size' => '8',
-      'Type' => 'Pointer'
-    },
-    '5824' => {
-      'BaseType' => '1088',
-      'Name' => 'ver32_t*',
-      'Size' => '8',
-      'Type' => 'Pointer'
-    },
-    '6753' => {
-      'BaseType' => '2831',
+    '11406' => {
+      'BaseType' => '344',
       'Name' => 'bitfield8_t*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '7217' => {
-      'BaseType' => '2843',
-      'Name' => 'bitfield8_t const*',
-      'Size' => '8',
-      'Type' => 'Pointer'
-    },
-    '8009' => {
-      'BaseType' => '3393',
-      'Name' => 'struct pldm_msg_hdr const*',
-      'Size' => '8',
-      'Type' => 'Pointer'
-    },
-    '8249' => {
-      'BaseType' => '3459',
-      'Name' => 'struct pldm_header_info*',
-      'Size' => '8',
-      'Type' => 'Pointer'
-    },
-    '8510' => {
-      'BaseType' => '3538',
-      'Name' => 'struct pldm_header_info const*',
-      'Size' => '8',
-      'Type' => 'Pointer'
-    },
-    '8515' => {
-      'BaseType' => '3282',
+    '13168' => {
+      'BaseType' => '801',
       'Name' => 'struct pldm_msg_hdr*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '10385' => {
+    '15038' => {
       'Header' => 'utils.h',
       'Line' => '20',
       'Memb' => {
         '0' => {
           'name' => 'ptr',
           'offset' => '0',
-          'type' => '1214'
+          'type' => '5868'
         },
         '1' => {
           'name' => 'length',
           'offset' => '8',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Name' => 'struct variable_field',
       'Size' => '16',
       'Type' => 'Struct'
     },
-    '10781' => {
-      'BaseType' => '10385',
+    '15434' => {
+      'BaseType' => '15038',
       'Name' => 'struct variable_field*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '12863' => {
-      'BaseType' => '1006',
+    '17516' => {
+      'BaseType' => '5660',
       'Name' => 'uint16_t*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '13426' => {
-      'BaseType' => '1140',
-      'Name' => 'size_t*',
-      'Size' => '8',
-      'Type' => 'Pointer'
-    },
-    '16102' => {
+    '20755' => {
       'BaseType' => '67',
       'Header' => 'types.h',
       'Line' => '45',
@@ -10555,14 +10531,14 @@ $VAR1 = {
       'Size' => '8',
       'Type' => 'Typedef'
     },
-    '16179' => {
-      'BaseType' => '1006',
+    '20832' => {
+      'BaseType' => '5660',
       'Name' => 'uint16_t const',
       'Size' => '2',
       'Type' => 'Const'
     },
-    '16196' => {
-      'BaseType' => '16102',
+    '20849' => {
+      'BaseType' => '20755',
       'Header' => 'stdint-uintn.h',
       'Line' => '27',
       'Name' => 'uint64_t',
@@ -10570,7 +10546,7 @@ $VAR1 = {
       'Size' => '8',
       'Type' => 'Typedef'
     },
-    '16354' => {
+    '21007' => {
       'Header' => 'bios.h',
       'Line' => '39',
       'Memb' => {
@@ -10591,286 +10567,286 @@ $VAR1 = {
       'Size' => '4',
       'Type' => 'Enum'
     },
-    '16388' => {
+    '21041' => {
       'Header' => 'bios.h',
       'Line' => '48',
       'Memb' => {
         '0' => {
           'name' => 'string_handle',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '1' => {
           'name' => 'string_length',
           'offset' => '2',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'name',
           'offset' => '4',
-          'type' => '16445'
+          'type' => '21098'
         }
       },
       'Name' => 'struct pldm_bios_string_table_entry',
       'Size' => '5',
       'Type' => 'Struct'
     },
-    '16440' => {
-      'BaseType' => '16388',
+    '21093' => {
+      'BaseType' => '21041',
       'Name' => 'struct pldm_bios_string_table_entry const',
       'Size' => '5',
       'Type' => 'Const'
     },
-    '16445' => {
-      'BaseType' => '114',
+    '21098' => {
+      'BaseType' => '128',
       'Name' => 'char[1]',
       'Size' => '1',
       'Type' => 'Array'
     },
-    '16461' => {
+    '21114' => {
       'Header' => 'bios.h',
       'Line' => '54',
       'Memb' => {
         '0' => {
           'name' => 'attr_handle',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '1' => {
           'name' => 'attr_type',
           'offset' => '2',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'string_handle',
           'offset' => '3',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'metadata',
           'offset' => '5',
-          'type' => '3443'
+          'type' => '962'
         }
       },
       'Name' => 'struct pldm_bios_attr_table_entry',
       'Size' => '6',
       'Type' => 'Struct'
     },
-    '16526' => {
-      'BaseType' => '16461',
+    '21179' => {
+      'BaseType' => '21114',
       'Name' => 'struct pldm_bios_attr_table_entry const',
       'Size' => '6',
       'Type' => 'Const'
     },
-    '16531' => {
+    '21184' => {
       'Header' => 'bios.h',
       'Line' => '66',
       'Memb' => {
         '0' => {
           'name' => 'attr_handle',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '1' => {
           'name' => 'attr_type',
           'offset' => '2',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'value',
           'offset' => '3',
-          'type' => '3443'
+          'type' => '962'
         }
       },
       'Name' => 'struct pldm_bios_attr_val_table_entry',
       'Size' => '4',
       'Type' => 'Struct'
     },
-    '16583' => {
-      'BaseType' => '16531',
+    '21236' => {
+      'BaseType' => '21184',
       'Name' => 'struct pldm_bios_attr_val_table_entry const',
       'Size' => '4',
       'Type' => 'Const'
     },
-    '16652' => {
+    '21305' => {
       'Header' => 'bios_table.h',
       'Line' => '206',
       'Memb' => {
         '0' => {
           'name' => 'name_handle',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '1' => {
           'name' => 'read_only',
           'offset' => '2',
-          'type' => '805'
+          'type' => '5459'
         },
         '2' => {
           'name' => 'pv_num',
           'offset' => '3',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'pv_handle',
           'offset' => '8',
-          'type' => '16755'
+          'type' => '21408'
         },
         '4' => {
           'name' => 'def_num',
           'offset' => '22',
-          'type' => '121'
+          'type' => '135'
         },
         '5' => {
           'name' => 'def_index',
           'offset' => '36',
-          'type' => '1214'
+          'type' => '5868'
         }
       },
       'Name' => 'struct pldm_bios_table_attr_entry_enum_info',
       'Size' => '32',
       'Type' => 'Struct'
     },
-    '16743' => {
-      'BaseType' => '16652',
+    '21396' => {
+      'BaseType' => '21305',
       'Name' => 'struct pldm_bios_table_attr_entry_enum_info const',
       'Size' => '32',
       'Type' => 'Const'
     },
-    '16755' => {
-      'BaseType' => '16179',
+    '21408' => {
+      'BaseType' => '20832',
       'Name' => 'uint16_t const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '16765' => {
+    '21418' => {
       'Header' => 'bios_table.h',
       'Line' => '294',
       'Memb' => {
         '0' => {
           'name' => 'name_handle',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '1' => {
           'name' => 'read_only',
           'offset' => '2',
-          'type' => '805'
+          'type' => '5459'
         },
         '2' => {
           'name' => 'string_type',
           'offset' => '3',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'min_length',
           'offset' => '4',
-          'type' => '1006'
+          'type' => '5660'
         },
         '4' => {
           'name' => 'max_length',
           'offset' => '6',
-          'type' => '1006'
+          'type' => '5660'
         },
         '5' => {
           'name' => 'def_length',
           'offset' => '8',
-          'type' => '1006'
+          'type' => '5660'
         },
         '6' => {
           'name' => 'def_string',
           'offset' => '22',
-          'type' => '3999'
+          'type' => '8652'
         }
       },
       'Name' => 'struct pldm_bios_table_attr_entry_string_info',
       'Size' => '24',
       'Type' => 'Struct'
     },
-    '16877' => {
-      'BaseType' => '16765',
+    '21530' => {
+      'BaseType' => '21418',
       'Name' => 'struct pldm_bios_table_attr_entry_string_info const',
       'Size' => '24',
       'Type' => 'Const'
     },
-    '16887' => {
+    '21540' => {
       'Header' => 'bios_table.h',
       'Line' => '384',
       'Memb' => {
         '0' => {
           'name' => 'name_handle',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '1' => {
           'name' => 'read_only',
           'offset' => '2',
-          'type' => '805'
+          'type' => '5459'
         },
         '2' => {
           'name' => 'lower_bound',
           'offset' => '8',
-          'type' => '16196'
+          'type' => '20849'
         },
         '3' => {
           'name' => 'upper_bound',
           'offset' => '22',
-          'type' => '16196'
+          'type' => '20849'
         },
         '4' => {
           'name' => 'scalar_increment',
           'offset' => '36',
-          'type' => '1018'
+          'type' => '147'
         },
         '5' => {
           'name' => 'default_value',
           'offset' => '50',
-          'type' => '16196'
+          'type' => '20849'
         }
       },
       'Name' => 'struct pldm_bios_table_attr_entry_integer_info',
       'Size' => '40',
       'Type' => 'Struct'
     },
-    '16985' => {
-      'BaseType' => '16887',
+    '21638' => {
+      'BaseType' => '21540',
       'Name' => 'struct pldm_bios_table_attr_entry_integer_info const',
       'Size' => '40',
       'Type' => 'Const'
     },
-    '17268' => {
+    '21921' => {
       'Name' => 'ssize_t(*)(void const*)',
       'Param' => {
         '0' => {
-          'type' => '2396'
+          'type' => '1262'
         }
       },
-      'Return' => '1202',
+      'Return' => '5856',
       'Size' => '8',
       'Type' => 'FuncPtr'
     },
-    '17338' => {
+    '21991' => {
       'Line' => '957',
       'Memb' => {
         '0' => {
           'name' => 'table_data',
           'offset' => '0',
-          'type' => '1214'
+          'type' => '5868'
         },
         '1' => {
           'name' => 'table_len',
           'offset' => '8',
-          'type' => '1140'
+          'type' => '164'
         },
         '2' => {
           'name' => 'current_pos',
           'offset' => '22',
-          'type' => '1140'
+          'type' => '164'
         },
         '3' => {
           'name' => 'entry_length_handler',
           'offset' => '36',
-          'type' => '17268'
+          'type' => '21921'
         }
       },
       'Name' => 'struct pldm_bios_table_iter',
@@ -10879,921 +10855,915 @@ $VAR1 = {
       'Source' => 'bios_table.c',
       'Type' => 'Struct'
     },
-    '17408' => {
-      'BaseType' => '17338',
+    '22061' => {
+      'BaseType' => '21991',
       'Name' => 'struct pldm_bios_table_iter const',
       'Size' => '32',
       'Type' => 'Const'
     },
-    '18478' => {
-      'BaseType' => '17338',
+    '23131' => {
+      'BaseType' => '21991',
       'Name' => 'struct pldm_bios_table_iter*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '18483' => {
-      'BaseType' => '16583',
+    '23136' => {
+      'BaseType' => '21236',
       'Name' => 'struct pldm_bios_attr_val_table_entry const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '18897' => {
-      'BaseType' => '16526',
+    '23550' => {
+      'BaseType' => '21179',
       'Name' => 'struct pldm_bios_attr_table_entry const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '19500' => {
-      'BaseType' => '16440',
+    '24153' => {
+      'BaseType' => '21093',
       'Name' => 'struct pldm_bios_string_table_entry const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '20663' => {
-      'BaseType' => '17408',
+    '25316' => {
+      'BaseType' => '22061',
       'Name' => 'struct pldm_bios_table_iter const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '24846' => {
-      'BaseType' => '16196',
+    '29499' => {
+      'BaseType' => '20849',
       'Name' => 'uint64_t*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '25123' => {
-      'BaseType' => '16985',
+    '29776' => {
+      'BaseType' => '21638',
       'Name' => 'struct pldm_bios_table_attr_entry_integer_info const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '25432' => {
-      'BaseType' => '3999',
+    '30085' => {
+      'BaseType' => '8652',
       'Name' => 'char const**',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '26561' => {
-      'BaseType' => '16877',
+    '31214' => {
+      'BaseType' => '21530',
       'Name' => 'struct pldm_bios_table_attr_entry_string_info const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '28015' => {
-      'BaseType' => '16743',
+    '32668' => {
+      'BaseType' => '21396',
       'Name' => 'struct pldm_bios_table_attr_entry_enum_info const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '30176' => {
-      'BaseType' => '1018',
-      'Name' => 'uint32_t const',
-      'Size' => '4',
-      'Type' => 'Const'
-    },
-    '30217' => {
-      'BaseType' => '121',
+    '34885' => {
+      'BaseType' => '135',
       'Header' => 'pldm_types.h',
       'Line' => '32',
       'Name' => 'bool8_t',
       'Size' => '1',
       'Type' => 'Typedef'
     },
-    '30229' => {
+    '34897' => {
       'Header' => 'pldm_types.h',
       'Line' => '36',
       'Name' => 'anon-struct-pldm_types.h-36',
       'Size' => '2',
       'Type' => 'Struct'
     },
-    '30493' => {
+    '35161' => {
       'Header' => 'pldm_types.h',
       'Line' => '54',
       'Memb' => {
         '0' => {
           'name' => 'value',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '1' => {
           'name' => 'bits',
           'offset' => '0',
-          'type' => '30229'
+          'type' => '34897'
         }
       },
       'Name' => 'union bitfield16_t',
       'Size' => '2',
       'Type' => 'Union'
     },
-    '30505' => {
+    '35173' => {
       'Header' => 'pldm_types.h',
       'Line' => '58',
       'Name' => 'anon-struct-pldm_types.h-58',
       'Size' => '4',
       'Type' => 'Struct'
     },
-    '30993' => {
+    '35661' => {
       'Header' => 'pldm_types.h',
       'Line' => '92',
       'Memb' => {
         '0' => {
           'name' => 'value',
           'offset' => '0',
-          'type' => '1018'
+          'type' => '147'
         },
         '1' => {
           'name' => 'bits',
           'offset' => '0',
-          'type' => '30505'
+          'type' => '35173'
         }
       },
       'Name' => 'union bitfield32_t',
       'Size' => '4',
       'Type' => 'Union'
     },
-    '31005' => {
+    '35673' => {
       'Header' => 'pldm_types.h',
       'Line' => '96',
       'Name' => 'anon-struct-pldm_types.h-96',
       'Size' => '8',
       'Type' => 'Struct'
     },
-    '31941' => {
+    '36609' => {
       'Header' => 'pldm_types.h',
       'Line' => '162',
       'Memb' => {
         '0' => {
           'name' => 'value',
           'offset' => '0',
-          'type' => '16196'
+          'type' => '20849'
         },
         '1' => {
           'name' => 'bits',
           'offset' => '0',
-          'type' => '31005'
+          'type' => '35673'
         }
       },
       'Name' => 'union bitfield64_t',
       'Size' => '8',
       'Type' => 'Union'
     },
-    '32000' => {
-      'BaseType' => '1140',
+    '36668' => {
+      'BaseType' => '164',
       'Name' => 'size_t const',
       'Size' => '8',
       'Type' => 'Const'
     },
-    '32629' => {
-      'BaseType' => '10385',
+    '37302' => {
+      'BaseType' => '15038',
       'Name' => 'struct variable_field const',
       'Size' => '16',
       'Type' => 'Const'
     },
-    '33798' => {
+    '38592' => {
+      'BaseType' => '135',
+      'Name' => 'uint8_t[8]',
+      'Size' => '8',
+      'Type' => 'Array'
+    },
+    '38608' => {
       'Header' => 'firmware_update.h',
-      'Line' => '418',
+      'Line' => '441',
       'Memb' => {
         '0' => {
           'name' => 'uuid',
           'offset' => '0',
-          'type' => '33902'
+          'type' => '38712'
         },
         '1' => {
           'name' => 'package_header_format_version',
           'offset' => '22',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'package_header_size',
           'offset' => '23',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'package_release_date_time',
           'offset' => '25',
-          'type' => '33918'
+          'type' => '38728'
         },
         '4' => {
           'name' => 'component_bitmap_bit_length',
           'offset' => '50',
-          'type' => '1006'
+          'type' => '5660'
         },
         '5' => {
           'name' => 'package_version_string_type',
           'offset' => '52',
-          'type' => '121'
+          'type' => '135'
         },
         '6' => {
           'name' => 'package_version_string_length',
           'offset' => '53',
-          'type' => '121'
+          'type' => '135'
         }
       },
       'Name' => 'struct pldm_package_header_information',
       'Size' => '36',
       'Type' => 'Struct'
     },
-    '33902' => {
-      'BaseType' => '121',
+    '38712' => {
+      'BaseType' => '135',
       'Name' => 'uint8_t[16]',
       'Size' => '16',
       'Type' => 'Array'
     },
-    '33918' => {
-      'BaseType' => '121',
+    '38728' => {
+      'BaseType' => '135',
       'Name' => 'uint8_t[13]',
       'Size' => '13',
       'Type' => 'Array'
     },
-    '33934' => {
+    '38744' => {
       'Header' => 'firmware_update.h',
-      'Line' => '432',
+      'Line' => '455',
       'Memb' => {
         '0' => {
           'name' => 'record_length',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '1' => {
           'name' => 'descriptor_count',
           'offset' => '2',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'device_update_option_flags',
           'offset' => '3',
-          'type' => '30993'
+          'type' => '35661'
         },
         '3' => {
           'name' => 'comp_image_set_version_string_type',
           'offset' => '7',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'comp_image_set_version_string_length',
           'offset' => '8',
-          'type' => '121'
+          'type' => '135'
         },
         '5' => {
           'name' => 'fw_device_pkg_data_length',
           'offset' => '9',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Name' => 'struct pldm_firmware_device_id_record',
       'Size' => '11',
       'Type' => 'Struct'
     },
-    '34129' => {
+    '38939' => {
       'Header' => 'firmware_update.h',
-      'Line' => '466',
+      'Line' => '489',
       'Memb' => {
         '0' => {
           'name' => 'comp_classification',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '1' => {
           'name' => 'comp_identifier',
           'offset' => '2',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'comp_comparison_stamp',
           'offset' => '4',
-          'type' => '1018'
+          'type' => '147'
         },
         '3' => {
           'name' => 'comp_options',
           'offset' => '8',
-          'type' => '30493'
+          'type' => '35161'
         },
         '4' => {
           'name' => 'requested_comp_activation_method',
           'offset' => '16',
-          'type' => '30493'
+          'type' => '35161'
         },
         '5' => {
           'name' => 'comp_location_offset',
           'offset' => '18',
-          'type' => '1018'
+          'type' => '147'
         },
         '6' => {
           'name' => 'comp_size',
           'offset' => '22',
-          'type' => '1018'
+          'type' => '147'
         },
         '7' => {
           'name' => 'comp_version_string_type',
           'offset' => '32',
-          'type' => '121'
+          'type' => '135'
         },
         '8' => {
           'name' => 'comp_version_string_length',
           'offset' => '33',
-          'type' => '121'
+          'type' => '135'
         }
       },
       'Name' => 'struct pldm_component_image_information',
       'Size' => '22',
       'Type' => 'Struct'
     },
-    '34311' => {
+    '39121' => {
       'Header' => 'firmware_update.h',
-      'Line' => '492',
+      'Line' => '515',
       'Memb' => {
         '0' => {
           'name' => 'completion_code',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'capabilities_during_update',
           'offset' => '1',
-          'type' => '30993'
+          'type' => '35661'
         },
         '2' => {
           'name' => 'comp_count',
           'offset' => '5',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'active_comp_image_set_ver_str_type',
           'offset' => '7',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'active_comp_image_set_ver_str_len',
           'offset' => '8',
-          'type' => '121'
+          'type' => '135'
         },
         '5' => {
           'name' => 'pending_comp_image_set_ver_str_type',
           'offset' => '9',
-          'type' => '121'
+          'type' => '135'
         },
         '6' => {
           'name' => 'pending_comp_image_set_ver_str_len',
           'offset' => '16',
-          'type' => '121'
+          'type' => '135'
         }
       },
       'Name' => 'struct pldm_get_firmware_parameters_resp',
       'Size' => '11',
       'Type' => 'Struct'
     },
-    '34415' => {
+    '39308' => {
       'Header' => 'firmware_update.h',
-      'Line' => '508',
+      'Line' => '543',
       'Memb' => {
         '0' => {
           'name' => 'completion_code',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'downstream_device_update_supported',
           'offset' => '1',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'number_of_downstream_devices',
           'offset' => '2',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'max_number_of_downstream_devices',
           'offset' => '4',
-          'type' => '1006'
+          'type' => '5660'
         },
         '4' => {
           'name' => 'capabilities',
           'offset' => '8',
-          'type' => '30993'
+          'type' => '35661'
         }
       },
       'Name' => 'struct pldm_query_downstream_devices_resp',
       'Size' => '12',
       'Type' => 'Struct'
     },
-    '34493' => {
+    '39386' => {
       'Header' => 'firmware_update.h',
-      'Line' => '520',
+      'Line' => '555',
       'Memb' => {
         '0' => {
           'name' => 'comp_classification',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '1' => {
           'name' => 'comp_identifier',
           'offset' => '2',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'comp_classification_index',
           'offset' => '4',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'active_comp_comparison_stamp',
           'offset' => '5',
-          'type' => '1018'
+          'type' => '147'
         },
         '4' => {
           'name' => 'active_comp_ver_str_type',
           'offset' => '9',
-          'type' => '121'
+          'type' => '135'
         },
         '5' => {
           'name' => 'active_comp_ver_str_len',
           'offset' => '16',
-          'type' => '121'
+          'type' => '135'
         },
         '6' => {
           'name' => 'active_comp_release_date',
           'offset' => '17',
-          'type' => '34675'
+          'type' => '38592'
         },
         '7' => {
           'name' => 'pending_comp_comparison_stamp',
           'offset' => '25',
-          'type' => '1018'
+          'type' => '147'
         },
         '8' => {
           'name' => 'pending_comp_ver_str_type',
           'offset' => '35',
-          'type' => '121'
+          'type' => '135'
         },
         '9' => {
           'name' => 'pending_comp_ver_str_len',
           'offset' => '36',
-          'type' => '121'
+          'type' => '135'
         },
         '10' => {
           'name' => 'pending_comp_release_date',
           'offset' => '37',
-          'type' => '34675'
+          'type' => '38592'
         },
         '11' => {
           'name' => 'comp_activation_methods',
           'offset' => '51',
-          'type' => '30493'
+          'type' => '35161'
         },
         '12' => {
           'name' => 'capabilities_during_update',
           'offset' => '53',
-          'type' => '30993'
+          'type' => '35661'
         }
       },
       'Name' => 'struct pldm_component_parameter_entry',
       'Size' => '39',
       'Type' => 'Struct'
     },
-    '34675' => {
-      'BaseType' => '121',
-      'Name' => 'uint8_t[8]',
-      'Size' => '8',
-      'Type' => 'Array'
-    },
-    '34691' => {
+    '39677' => {
       'Header' => 'firmware_update.h',
-      'Line' => '541',
+      'Line' => '594',
       'Memb' => {
         '0' => {
           'name' => 'data_transfer_handle',
           'offset' => '0',
-          'type' => '1018'
+          'type' => '147'
         },
         '1' => {
           'name' => 'transfer_operation_flag',
           'offset' => '4',
-          'type' => '121'
+          'type' => '135'
         }
       },
       'Name' => 'struct pldm_query_downstream_identifiers_req',
       'Size' => '8',
       'Type' => 'Struct'
     },
-    '34730' => {
-      'BaseType' => '34691',
+    '39716' => {
+      'BaseType' => '39677',
       'Name' => 'struct pldm_query_downstream_identifiers_req const',
       'Size' => '8',
       'Type' => 'Const'
     },
-    '34735' => {
+    '39721' => {
       'Header' => 'firmware_update.h',
-      'Line' => '555',
+      'Line' => '608',
       'Memb' => {
         '0' => {
           'name' => 'completion_code',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'next_data_transfer_handle',
           'offset' => '4',
-          'type' => '1018'
+          'type' => '147'
         },
         '2' => {
           'name' => 'transfer_flag',
           'offset' => '8',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'downstream_devices_length',
           'offset' => '18',
-          'type' => '1018'
+          'type' => '147'
         },
         '4' => {
           'name' => 'number_of_downstream_devices',
           'offset' => '22',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Name' => 'struct pldm_query_downstream_identifiers_resp',
       'Size' => '20',
       'Type' => 'Struct'
     },
-    '34813' => {
+    '39799' => {
       'Header' => 'firmware_update.h',
-      'Line' => '568',
+      'Line' => '621',
       'Memb' => {
         '0' => {
           'name' => 'downstream_device_index',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '1' => {
           'name' => 'downstream_descriptor_count',
           'offset' => '2',
-          'type' => '121'
+          'type' => '135'
         }
       },
       'Name' => 'struct pldm_downstream_device',
       'Size' => '4',
       'Type' => 'Struct'
     },
-    '34852' => {
+    '39838' => {
       'Header' => 'firmware_update.h',
-      'Line' => '574',
+      'Line' => '627',
       'Memb' => {
         '0' => {
           'name' => 'field',
           'offset' => '0',
-          'type' => '10385'
+          'type' => '15038'
         },
         '1' => {
           'name' => 'devs',
           'offset' => '22',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Name' => 'struct pldm_downstream_device_iter',
       'Size' => '24',
       'Type' => 'Struct'
     },
-    '34891' => {
+    '39877' => {
       'Header' => 'firmware_update.h',
-      'Line' => '648',
+      'Line' => '701',
       'Memb' => {
         '0' => {
           'name' => 'descriptor_type',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '1' => {
           'name' => 'descriptor_length',
           'offset' => '2',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'descriptor_data',
           'offset' => '8',
-          'type' => '2396'
+          'type' => '1262'
         }
       },
       'Name' => 'struct pldm_descriptor',
       'Size' => '16',
       'Type' => 'Struct'
     },
-    '34954' => {
+    '39945' => {
       'Header' => 'firmware_update.h',
-      'Line' => '654',
+      'Line' => '707',
       'Memb' => {
         '0' => {
           'name' => 'field',
           'offset' => '0',
-          'type' => '10781'
+          'type' => '15434'
         },
         '1' => {
           'name' => 'count',
           'offset' => '8',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Name' => 'struct pldm_descriptor_iter',
       'Size' => '16',
       'Type' => 'Struct'
     },
-    '34998' => {
+    '39989' => {
       'Header' => 'firmware_update.h',
-      'Line' => '747',
+      'Line' => '800',
       'Memb' => {
         '0' => {
           'name' => 'data_transfer_handle',
           'offset' => '0',
-          'type' => '1018'
+          'type' => '147'
         },
         '1' => {
           'name' => 'transfer_operation_flag',
           'offset' => '4',
-          'type' => '121'
+          'type' => '135'
         }
       },
       'Name' => 'struct pldm_get_downstream_firmware_parameters_req',
       'Size' => '8',
       'Type' => 'Struct'
     },
-    '35037' => {
-      'BaseType' => '34998',
+    '40028' => {
+      'BaseType' => '39989',
       'Name' => 'struct pldm_get_downstream_firmware_parameters_req const',
       'Size' => '8',
       'Type' => 'Const'
     },
-    '35042' => {
+    '40033' => {
       'Header' => 'firmware_update.h',
-      'Line' => '762',
+      'Line' => '815',
       'Memb' => {
         '0' => {
           'name' => 'completion_code',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'next_data_transfer_handle',
           'offset' => '4',
-          'type' => '1018'
+          'type' => '147'
         },
         '2' => {
           'name' => 'transfer_flag',
           'offset' => '8',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'fdp_capabilities_during_update',
           'offset' => '18',
-          'type' => '30993'
+          'type' => '35661'
         },
         '4' => {
           'name' => 'downstream_device_count',
           'offset' => '22',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Name' => 'struct pldm_get_downstream_firmware_parameters_resp',
       'Size' => '20',
       'Type' => 'Struct'
     },
-    '35120' => {
+    '40111' => {
       'Header' => 'firmware_update.h',
-      'Line' => '780',
+      'Line' => '833',
       'Memb' => {
         '0' => {
           'name' => 'downstream_device_index',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '1' => {
           'name' => 'active_comp_comparison_stamp',
           'offset' => '4',
-          'type' => '1018'
+          'type' => '147'
         },
         '2' => {
           'name' => 'active_comp_ver_str_type',
           'offset' => '8',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'active_comp_ver_str_len',
           'offset' => '9',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'active_comp_release_date',
           'offset' => '16',
-          'type' => '35302'
+          'type' => '40293'
         },
         '5' => {
           'name' => 'pending_comp_comparison_stamp',
           'offset' => '32',
-          'type' => '1018'
+          'type' => '147'
         },
         '6' => {
           'name' => 'pending_comp_ver_str_type',
           'offset' => '36',
-          'type' => '121'
+          'type' => '135'
         },
         '7' => {
           'name' => 'pending_comp_ver_str_len',
           'offset' => '37',
-          'type' => '121'
+          'type' => '135'
         },
         '8' => {
           'name' => 'pending_comp_release_date',
           'offset' => '38',
-          'type' => '35302'
+          'type' => '40293'
         },
         '9' => {
           'name' => 'comp_activation_methods',
           'offset' => '54',
-          'type' => '30493'
+          'type' => '35161'
         },
         '10' => {
           'name' => 'capabilities_during_update',
           'offset' => '64',
-          'type' => '30993'
+          'type' => '35661'
         },
         '11' => {
           'name' => 'active_comp_ver_str',
           'offset' => '72',
-          'type' => '2396'
+          'type' => '1262'
         },
         '12' => {
           'name' => 'pending_comp_ver_str',
           'offset' => '86',
-          'type' => '2396'
+          'type' => '1262'
         }
       },
       'Name' => 'struct pldm_downstream_device_parameters_entry',
       'Size' => '64',
       'Type' => 'Struct'
     },
-    '35302' => {
-      'BaseType' => '114',
+    '40293' => {
+      'BaseType' => '128',
       'Name' => 'char[9]',
       'Size' => '9',
       'Type' => 'Array'
     },
-    '36124' => {
+    '41428' => {
       'Header' => 'firmware_update.h',
-      'Line' => '1198',
+      'Line' => '1347',
       'Memb' => {
         '0' => {
           'name' => 'field',
           'offset' => '0',
-          'type' => '10385'
+          'type' => '15038'
         },
         '1' => {
           'name' => 'entries',
           'offset' => '22',
-          'type' => '1140'
+          'type' => '164'
         }
       },
       'Name' => 'struct pldm_downstream_device_parameters_iter',
       'Size' => '24',
       'Type' => 'Struct'
     },
-    '36527' => {
-      'BaseType' => '30217',
+    '42723' => {
+      'BaseType' => '34885',
       'Name' => 'bool8_t*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '36532' => {
-      'BaseType' => '31941',
+    '42728' => {
+      'BaseType' => '36609',
       'Name' => 'bitfield64_t*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '37287' => {
-      'BaseType' => '30993',
+    '44972' => {
+      'BaseType' => '35661',
       'Name' => 'bitfield32_t*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '38136' => {
-      'BaseType' => '30493',
+    '47633' => {
+      'BaseType' => '35161',
       'Name' => 'bitfield16_t*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '39690' => {
-      'BaseType' => '32629',
+    '54224' => {
+      'BaseType' => '37302',
       'Name' => 'struct variable_field const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '43532' => {
-      'BaseType' => '36124',
+    '63257' => {
+      'BaseType' => '41428',
       'Name' => 'struct pldm_downstream_device_parameters_iter*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '43537' => {
-      'BaseType' => '35120',
+    '63262' => {
+      'BaseType' => '40111',
       'Name' => 'struct pldm_downstream_device_parameters_entry*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '44902' => {
-      'BaseType' => '35042',
+    '64622' => {
+      'BaseType' => '40033',
       'Name' => 'struct pldm_get_downstream_firmware_parameters_resp*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '45592' => {
-      'BaseType' => '35037',
+    '65310' => {
+      'BaseType' => '40028',
       'Name' => 'struct pldm_get_downstream_firmware_parameters_req const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '46348' => {
-      'BaseType' => '34852',
+    '66066' => {
+      'BaseType' => '39838',
       'Name' => 'struct pldm_downstream_device_iter*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '46353' => {
-      'BaseType' => '34813',
+    '66071' => {
+      'BaseType' => '39799',
       'Name' => 'struct pldm_downstream_device*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '47726' => {
-      'BaseType' => '34735',
+    '67444' => {
+      'BaseType' => '39721',
       'Name' => 'struct pldm_query_downstream_identifiers_resp*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '48414' => {
-      'BaseType' => '34730',
+    '68132' => {
+      'BaseType' => '39716',
       'Name' => 'struct pldm_query_downstream_identifiers_req const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '49718' => {
-      'BaseType' => '34415',
+    '69436' => {
+      'BaseType' => '39308',
       'Name' => 'struct pldm_query_downstream_devices_resp*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '50165' => {
-      'BaseType' => '34493',
+    '69883' => {
+      'BaseType' => '39386',
       'Name' => 'struct pldm_component_parameter_entry*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '50390' => {
-      'BaseType' => '34311',
+    '74903' => {
+      'BaseType' => '39121',
       'Name' => 'struct pldm_get_firmware_parameters_resp*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '50691' => {
-      'BaseType' => '4919',
+    '76759' => {
+      'BaseType' => '1186',
       'Name' => 'uint8_t**',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '50988' => {
-      'BaseType' => '34129',
+    '77101' => {
+      'BaseType' => '38939',
       'Name' => 'struct pldm_component_image_information*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '52278' => {
-      'BaseType' => '34954',
+    '78952' => {
+      'BaseType' => '39945',
       'Name' => 'struct pldm_descriptor_iter*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '52283' => {
-      'BaseType' => '34891',
+    '78957' => {
+      'BaseType' => '39877',
       'Name' => 'struct pldm_descriptor*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '52545' => {
-      'BaseType' => '33934',
+    '79242' => {
+      'BaseType' => '38744',
       'Name' => 'struct pldm_firmware_device_id_record*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '52855' => {
-      'BaseType' => '33798',
+    '79697' => {
+      'BaseType' => '38608',
       'Name' => 'struct pldm_package_header_information*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '53604' => {
-      'BaseType' => '2634',
+    '80830' => {
+      'BaseType' => '126',
       'Name' => 'void**',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '60581' => {
-      'BaseType' => '60598',
+    '88331' => {
+      'BaseType' => '88348',
       'Header' => 'pdr.h',
       'Line' => '16',
       'Name' => 'pldm_pdr',
@@ -11801,34 +11771,34 @@ $VAR1 = {
       'Size' => '24',
       'Type' => 'Typedef'
     },
-    '60593' => {
-      'BaseType' => '60581',
+    '88343' => {
+      'BaseType' => '88331',
       'Name' => 'pldm_pdr const',
       'Size' => '24',
       'Type' => 'Const'
     },
-    '60598' => {
+    '88348' => {
       'Line' => '30',
       'Memb' => {
         '0' => {
           'name' => 'record_count',
           'offset' => '0',
-          'type' => '1018'
+          'type' => '147'
         },
         '1' => {
           'name' => 'size',
           'offset' => '4',
-          'type' => '1018'
+          'type' => '147'
         },
         '2' => {
           'name' => 'first',
           'offset' => '8',
-          'type' => '61697'
+          'type' => '89447'
         },
         '3' => {
           'name' => 'last',
           'offset' => '22',
-          'type' => '61697'
+          'type' => '89447'
         }
       },
       'Name' => 'struct pldm_pdr',
@@ -11837,8 +11807,8 @@ $VAR1 = {
       'Source' => 'pdr.c',
       'Type' => 'Struct'
     },
-    '60664' => {
-      'BaseType' => '60681',
+    '88414' => {
+      'BaseType' => '88431',
       'Header' => 'pdr.h',
       'Line' => '21',
       'Name' => 'pldm_pdr_record',
@@ -11846,44 +11816,44 @@ $VAR1 = {
       'Size' => '32',
       'Type' => 'Typedef'
     },
-    '60676' => {
-      'BaseType' => '60664',
+    '88426' => {
+      'BaseType' => '88414',
       'Name' => 'pldm_pdr_record const',
       'Size' => '32',
       'Type' => 'Const'
     },
-    '60681' => {
+    '88431' => {
       'Line' => '21',
       'Memb' => {
         '0' => {
           'name' => 'record_handle',
           'offset' => '0',
-          'type' => '1018'
+          'type' => '147'
         },
         '1' => {
           'name' => 'size',
           'offset' => '4',
-          'type' => '1018'
+          'type' => '147'
         },
         '2' => {
           'name' => 'data',
           'offset' => '8',
-          'type' => '4919'
+          'type' => '1186'
         },
         '3' => {
           'name' => 'next',
           'offset' => '22',
-          'type' => '61685'
+          'type' => '89435'
         },
         '4' => {
           'name' => 'is_remote',
           'offset' => '36',
-          'type' => '805'
+          'type' => '5459'
         },
         '5' => {
           'name' => 'terminus_handle',
           'offset' => '38',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Name' => 'struct pldm_pdr_record',
@@ -11892,40 +11862,40 @@ $VAR1 = {
       'Source' => 'pdr.c',
       'Type' => 'Struct'
     },
-    '60773' => {
+    '88523' => {
       'Header' => 'pdr.h',
       'Line' => '288',
       'Memb' => {
         '0' => {
           'name' => 'entity_type',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '1' => {
           'name' => 'entity_instance_num',
           'offset' => '2',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'entity_container_id',
           'offset' => '4',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Name' => 'struct pldm_entity',
       'Size' => '6',
       'Type' => 'Struct'
     },
-    '60835' => {
-      'BaseType' => '60773',
+    '88585' => {
+      'BaseType' => '88523',
       'Header' => 'pdr.h',
       'Line' => '292',
       'Name' => 'pldm_entity',
       'Size' => '6',
       'Type' => 'Typedef'
     },
-    '60879' => {
-      'BaseType' => '60891',
+    '88629' => {
+      'BaseType' => '88641',
       'Header' => 'pdr.h',
       'Line' => '302',
       'Name' => 'pldm_entity_association_tree',
@@ -11933,18 +11903,18 @@ $VAR1 = {
       'Size' => '16',
       'Type' => 'Typedef'
     },
-    '60891' => {
-      'Line' => '451',
+    '88641' => {
+      'Line' => '459',
       'Memb' => {
         '0' => {
           'name' => 'root',
           'offset' => '0',
-          'type' => '61702'
+          'type' => '89452'
         },
         '1' => {
           'name' => 'last_used_container_id',
           'offset' => '8',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Name' => 'struct pldm_entity_association_tree',
@@ -11953,8 +11923,8 @@ $VAR1 = {
       'Source' => 'pdr.c',
       'Type' => 'Struct'
     },
-    '60934' => {
-      'BaseType' => '60951',
+    '88684' => {
+      'BaseType' => '88701',
       'Header' => 'pdr.h',
       'Line' => '307',
       'Name' => 'pldm_entity_node',
@@ -11962,44 +11932,44 @@ $VAR1 = {
       'Size' => '40',
       'Type' => 'Typedef'
     },
-    '60946' => {
-      'BaseType' => '60934',
+    '88696' => {
+      'BaseType' => '88684',
       'Name' => 'pldm_entity_node const',
       'Size' => '40',
       'Type' => 'Const'
     },
-    '60951' => {
-      'Line' => '456',
+    '88701' => {
+      'Line' => '464',
       'Memb' => {
         '0' => {
           'name' => 'entity',
           'offset' => '0',
-          'type' => '60835'
+          'type' => '88585'
         },
         '1' => {
           'name' => 'parent',
           'offset' => '6',
-          'type' => '60835'
+          'type' => '88585'
         },
         '2' => {
           'name' => 'remote_container_id',
           'offset' => '18',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'first_child',
           'offset' => '22',
-          'type' => '61702'
+          'type' => '89452'
         },
         '4' => {
           'name' => 'next_sibling',
           'offset' => '36',
-          'type' => '61702'
+          'type' => '89452'
         },
         '5' => {
           'name' => 'association_type',
           'offset' => '50',
-          'type' => '121'
+          'type' => '135'
         }
       },
       'Name' => 'struct pldm_entity_node',
@@ -12008,107 +11978,107 @@ $VAR1 = {
       'Source' => 'pdr.c',
       'Type' => 'Struct'
     },
-    '61225' => {
+    '88975' => {
       'Header' => 'platform.h',
       'Line' => '551',
       'Memb' => {
         '0' => {
           'name' => 'record_handle',
           'offset' => '0',
-          'type' => '1018'
+          'type' => '147'
         },
         '1' => {
           'name' => 'version',
           'offset' => '4',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'type',
           'offset' => '5',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'record_change_num',
           'offset' => '6',
-          'type' => '1006'
+          'type' => '5660'
         },
         '4' => {
           'name' => 'length',
           'offset' => '8',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Name' => 'struct pldm_pdr_hdr',
       'Size' => '10',
       'Type' => 'Struct'
     },
-    '61685' => {
-      'BaseType' => '60681',
+    '89435' => {
+      'BaseType' => '88431',
       'Name' => 'struct pldm_pdr_record*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '61697' => {
-      'BaseType' => '60664',
+    '89447' => {
+      'BaseType' => '88414',
       'Name' => 'pldm_pdr_record*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '61702' => {
-      'BaseType' => '60934',
+    '89452' => {
+      'BaseType' => '88684',
       'Name' => 'pldm_entity_node*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '62571' => {
-      'BaseType' => '60581',
+    '90321' => {
+      'BaseType' => '88331',
       'Name' => 'pldm_pdr*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '63521' => {
-      'BaseType' => '60676',
+    '91271' => {
+      'BaseType' => '88426',
       'Name' => 'pldm_pdr_record const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '67691' => {
-      'BaseType' => '60835',
+    '95475' => {
+      'BaseType' => '88585',
       'Name' => 'pldm_entity*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '77026' => {
-      'BaseType' => '67691',
+    '104810' => {
+      'BaseType' => '95475',
       'Name' => 'pldm_entity**',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '77090' => {
-      'BaseType' => '60879',
+    '104874' => {
+      'BaseType' => '88629',
       'Name' => 'pldm_entity_association_tree*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '77678' => {
-      'BaseType' => '61702',
+    '105462' => {
+      'BaseType' => '89452',
       'Name' => 'pldm_entity_node**',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '78467' => {
-      'BaseType' => '60593',
+    '106251' => {
+      'BaseType' => '88343',
       'Name' => 'pldm_pdr const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '83705' => {
-      'BaseType' => '60946',
+    '111489' => {
+      'BaseType' => '88696',
       'Name' => 'pldm_entity_node const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '88500' => {
+    '116286' => {
       'BaseType' => '74',
       'Header' => 'types.h',
       'Line' => '37',
@@ -12117,7 +12087,7 @@ $VAR1 = {
       'Size' => '1',
       'Type' => 'Typedef'
     },
-    '88531' => {
+    '116317' => {
       'BaseType' => '93',
       'Header' => 'types.h',
       'Line' => '39',
@@ -12126,7 +12096,7 @@ $VAR1 = {
       'Size' => '2',
       'Type' => 'Typedef'
     },
-    '88562' => {
+    '116348' => {
       'BaseType' => '100',
       'Header' => 'types.h',
       'Line' => '41',
@@ -12135,8 +12105,8 @@ $VAR1 = {
       'Size' => '4',
       'Type' => 'Typedef'
     },
-    '88600' => {
-      'BaseType' => '927',
+    '116386' => {
+      'BaseType' => '5581',
       'Header' => 'types.h',
       'Line' => '55',
       'Name' => '__uint_least16_t',
@@ -12144,8 +12114,8 @@ $VAR1 = {
       'Size' => '2',
       'Type' => 'Typedef'
     },
-    '88653' => {
-      'BaseType' => '88500',
+    '116439' => {
+      'BaseType' => '116286',
       'Header' => 'stdint-intn.h',
       'Line' => '24',
       'Name' => 'int8_t',
@@ -12153,8 +12123,8 @@ $VAR1 = {
       'Size' => '1',
       'Type' => 'Typedef'
     },
-    '88665' => {
-      'BaseType' => '88531',
+    '116451' => {
+      'BaseType' => '116317',
       'Header' => 'stdint-intn.h',
       'Line' => '25',
       'Name' => 'int16_t',
@@ -12162,8 +12132,8 @@ $VAR1 = {
       'Size' => '2',
       'Type' => 'Typedef'
     },
-    '88677' => {
-      'BaseType' => '88562',
+    '116463' => {
+      'BaseType' => '116348',
       'Header' => 'stdint-intn.h',
       'Line' => '26',
       'Name' => 'int32_t',
@@ -12171,16 +12141,16 @@ $VAR1 = {
       'Size' => '4',
       'Type' => 'Typedef'
     },
-    '88942' => {
-      'BaseType' => '133',
+    '116728' => {
+      'BaseType' => '444',
       'Header' => 'pldm_types.h',
       'Line' => '164',
       'Name' => 'real32_t',
       'Size' => '4',
       'Type' => 'Typedef'
     },
-    '89599' => {
-      'BaseType' => '88600',
+    '117385' => {
+      'BaseType' => '116386',
       'Header' => 'uchar.h',
       'Line' => '51',
       'Name' => 'char16_t',
@@ -12188,7 +12158,7 @@ $VAR1 = {
       'Size' => '2',
       'Type' => 'Typedef'
     },
-    '90425' => {
+    '118211' => {
       'Header' => 'platform.h',
       'Line' => '329',
       'Memb' => {
@@ -12209,1022 +12179,1022 @@ $VAR1 = {
       'Size' => '4',
       'Type' => 'Enum'
     },
-    '90459' => {
-      'BaseType' => '90425',
+    '118245' => {
+      'BaseType' => '118211',
       'Name' => 'enum sensor_event_class_states const',
       'Size' => '4',
       'Type' => 'Const'
     },
-    '90767' => {
+    '118553' => {
       'Header' => 'platform.h',
       'Line' => '626',
       'Memb' => {
         '0' => {
           'name' => 'hdr',
           'offset' => '0',
-          'type' => '61225'
+          'type' => '88975'
         },
         '1' => {
           'name' => 'terminus_handle',
           'offset' => '16',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'sensor_id',
           'offset' => '18',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'entity_type',
           'offset' => '20',
-          'type' => '1006'
+          'type' => '5660'
         },
         '4' => {
           'name' => 'entity_instance',
           'offset' => '22',
-          'type' => '1006'
+          'type' => '5660'
         },
         '5' => {
           'name' => 'container_id',
           'offset' => '24',
-          'type' => '1006'
+          'type' => '5660'
         },
         '6' => {
           'name' => 'sensor_init',
           'offset' => '32',
-          'type' => '121'
+          'type' => '135'
         },
         '7' => {
           'name' => 'sensor_auxiliary_names_pdr',
           'offset' => '33',
-          'type' => '30217'
+          'type' => '34885'
         },
         '8' => {
           'name' => 'composite_sensor_count',
           'offset' => '34',
-          'type' => '121'
+          'type' => '135'
         },
         '9' => {
           'name' => 'possible_states',
           'offset' => '35',
-          'type' => '3443'
+          'type' => '962'
         }
       },
       'Name' => 'struct pldm_state_sensor_pdr',
       'Size' => '24',
       'Type' => 'Struct'
     },
-    '90921' => {
+    '118707' => {
       'Header' => 'platform.h',
       'Line' => '643',
       'Memb' => {
         '0' => {
           'name' => 'state_set_id',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '1' => {
           'name' => 'possible_states_size',
           'offset' => '2',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'states',
           'offset' => '3',
-          'type' => '90983'
+          'type' => '118769'
         }
       },
       'Name' => 'struct state_sensor_possible_states',
       'Size' => '4',
       'Type' => 'Struct'
     },
-    '90978' => {
-      'BaseType' => '90921',
+    '118764' => {
+      'BaseType' => '118707',
       'Name' => 'struct state_sensor_possible_states const',
       'Size' => '4',
       'Type' => 'Const'
     },
-    '90983' => {
-      'BaseType' => '2831',
+    '118769' => {
+      'BaseType' => '344',
       'Name' => 'bitfield8_t[1]',
       'Size' => '1',
       'Type' => 'Array'
     },
-    '90999' => {
+    '118785' => {
       'Header' => 'platform.h',
       'Line' => '653',
       'Memb' => {
         '0' => {
           'name' => 'hdr',
           'offset' => '0',
-          'type' => '61225'
+          'type' => '88975'
         },
         '1' => {
           'name' => 'terminus_handle',
           'offset' => '16',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'effecter_id',
           'offset' => '18',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'entity_type',
           'offset' => '20',
-          'type' => '1006'
+          'type' => '5660'
         },
         '4' => {
           'name' => 'entity_instance',
           'offset' => '22',
-          'type' => '1006'
+          'type' => '5660'
         },
         '5' => {
           'name' => 'container_id',
           'offset' => '24',
-          'type' => '1006'
+          'type' => '5660'
         },
         '6' => {
           'name' => 'effecter_semantic_id',
           'offset' => '32',
-          'type' => '1006'
+          'type' => '5660'
         },
         '7' => {
           'name' => 'effecter_init',
           'offset' => '34',
-          'type' => '121'
+          'type' => '135'
         },
         '8' => {
           'name' => 'has_description_pdr',
           'offset' => '35',
-          'type' => '30217'
+          'type' => '34885'
         },
         '9' => {
           'name' => 'composite_effecter_count',
           'offset' => '36',
-          'type' => '121'
+          'type' => '135'
         },
         '10' => {
           'name' => 'possible_states',
           'offset' => '37',
-          'type' => '3443'
+          'type' => '962'
         }
       },
       'Name' => 'struct pldm_state_effecter_pdr',
       'Size' => '26',
       'Type' => 'Struct'
     },
-    '91352' => {
+    '119138' => {
       'Header' => 'platform.h',
       'Line' => '744',
       'Memb' => {
         '0' => {
           'name' => 'value_u8',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'value_s8',
           'offset' => '0',
-          'type' => '88653'
+          'type' => '116439'
         },
         '2' => {
           'name' => 'value_u16',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'value_s16',
           'offset' => '0',
-          'type' => '88665'
+          'type' => '116451'
         },
         '4' => {
           'name' => 'value_u32',
           'offset' => '0',
-          'type' => '1018'
+          'type' => '147'
         },
         '5' => {
           'name' => 'value_s32',
           'offset' => '0',
-          'type' => '88677'
+          'type' => '116463'
         },
         '6' => {
           'name' => 'value_f32',
           'offset' => '0',
-          'type' => '88942'
+          'type' => '116728'
         }
       },
       'Name' => 'union union_range_field_format',
       'Size' => '4',
       'Type' => 'Union'
     },
-    '91949' => {
+    '119735' => {
       'Header' => 'platform.h',
       'Line' => '801',
       'Memb' => {
         '0' => {
           'name' => 'value_u8',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'value_s8',
           'offset' => '0',
-          'type' => '88653'
+          'type' => '116439'
         },
         '2' => {
           'name' => 'value_u16',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'value_s16',
           'offset' => '0',
-          'type' => '88665'
+          'type' => '116451'
         },
         '4' => {
           'name' => 'value_u32',
           'offset' => '0',
-          'type' => '1018'
+          'type' => '147'
         },
         '5' => {
           'name' => 'value_s32',
           'offset' => '0',
-          'type' => '88677'
+          'type' => '116463'
         }
       },
       'Name' => 'union union_sensor_data_size',
       'Size' => '4',
       'Type' => 'Union'
     },
-    '91962' => {
+    '119748' => {
       'Header' => 'platform.h',
       'Line' => '808',
       'Memb' => {
         '0' => {
           'name' => 'record_handle',
           'offset' => '0',
-          'type' => '1018'
+          'type' => '147'
         },
         '1' => {
           'name' => 'version',
           'offset' => '4',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'type',
           'offset' => '5',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'record_change_num',
           'offset' => '6',
-          'type' => '1006'
+          'type' => '5660'
         },
         '4' => {
           'name' => 'length',
           'offset' => '8',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Name' => 'struct pldm_value_pdr_hdr',
       'Size' => '12',
       'Type' => 'Struct'
     },
-    '92047' => {
+    '119833' => {
       'Header' => 'platform.h',
       'Line' => '826',
       'Memb' => {
         '0' => {
           'name' => 'entity_instance_num',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '1' => {
           'name' => 'entity_instance',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Name' => 'anon-union-platform.h-826',
       'Size' => '2',
       'Type' => 'Union'
     },
-    '92082' => {
+    '119868' => {
       'Header' => 'platform.h',
       'Line' => '821',
       'Memb' => {
         '0' => {
           'name' => 'hdr',
           'offset' => '0',
-          'type' => '91962'
+          'type' => '119748'
         },
         '1' => {
           'name' => 'terminus_handle',
           'offset' => '18',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'sensor_id',
           'offset' => '20',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'entity_type',
           'offset' => '22',
-          'type' => '1006'
+          'type' => '5660'
         },
         '4' => {
           'name' => 'unnamed0',
           'offset' => '24',
-          'type' => '92047'
+          'type' => '119833'
         },
         '5' => {
           'name' => 'container_id',
           'offset' => '32',
-          'type' => '1006'
+          'type' => '5660'
         },
         '6' => {
           'name' => 'sensor_init',
           'offset' => '34',
-          'type' => '121'
+          'type' => '135'
         },
         '7' => {
           'name' => 'sensor_auxiliary_names_pdr',
           'offset' => '35',
-          'type' => '30217'
+          'type' => '34885'
         },
         '8' => {
           'name' => 'base_unit',
           'offset' => '36',
-          'type' => '121'
+          'type' => '135'
         },
         '9' => {
           'name' => 'unit_modifier',
           'offset' => '37',
-          'type' => '88653'
+          'type' => '116439'
         },
         '10' => {
           'name' => 'rate_unit',
           'offset' => '38',
-          'type' => '121'
+          'type' => '135'
         },
         '11' => {
           'name' => 'base_oem_unit_handle',
           'offset' => '39',
-          'type' => '121'
+          'type' => '135'
         },
         '12' => {
           'name' => 'aux_unit',
           'offset' => '40',
-          'type' => '121'
+          'type' => '135'
         },
         '13' => {
           'name' => 'aux_unit_modifier',
           'offset' => '41',
-          'type' => '88653'
+          'type' => '116439'
         },
         '14' => {
           'name' => 'aux_rate_unit',
           'offset' => '48',
-          'type' => '121'
+          'type' => '135'
         },
         '15' => {
           'name' => 'rel',
           'offset' => '49',
-          'type' => '121'
+          'type' => '135'
         },
         '16' => {
           'name' => 'aux_oem_unit_handle',
           'offset' => '50',
-          'type' => '121'
+          'type' => '135'
         },
         '17' => {
           'name' => 'is_linear',
           'offset' => '51',
-          'type' => '30217'
+          'type' => '34885'
         },
         '18' => {
           'name' => 'sensor_data_size',
           'offset' => '52',
-          'type' => '121'
+          'type' => '135'
         },
         '19' => {
           'name' => 'resolution',
           'offset' => '54',
-          'type' => '88942'
+          'type' => '116728'
         },
         '20' => {
           'name' => 'offset',
           'offset' => '64',
-          'type' => '88942'
+          'type' => '116728'
         },
         '21' => {
           'name' => 'accuracy',
           'offset' => '68',
-          'type' => '1006'
+          'type' => '5660'
         },
         '22' => {
           'name' => 'plus_tolerance',
           'offset' => '70',
-          'type' => '121'
+          'type' => '135'
         },
         '23' => {
           'name' => 'minus_tolerance',
           'offset' => '71',
-          'type' => '121'
+          'type' => '135'
         },
         '24' => {
           'name' => 'hysteresis',
           'offset' => '72',
-          'type' => '91949'
+          'type' => '119735'
         },
         '25' => {
           'name' => 'supported_thresholds',
           'offset' => '82',
-          'type' => '2831'
+          'type' => '344'
         },
         '26' => {
           'name' => 'threshold_and_hysteresis_volatility',
           'offset' => '83',
-          'type' => '2831'
+          'type' => '344'
         },
         '27' => {
           'name' => 'state_transition_interval',
           'offset' => '86',
-          'type' => '88942'
+          'type' => '116728'
         },
         '28' => {
           'name' => 'update_interval',
           'offset' => '96',
-          'type' => '88942'
+          'type' => '116728'
         },
         '29' => {
           'name' => 'max_readable',
           'offset' => '100',
-          'type' => '91949'
+          'type' => '119735'
         },
         '30' => {
           'name' => 'min_readable',
           'offset' => '104',
-          'type' => '91949'
+          'type' => '119735'
         },
         '31' => {
           'name' => 'range_field_format',
           'offset' => '114',
-          'type' => '121'
+          'type' => '135'
         },
         '32' => {
           'name' => 'range_field_support',
           'offset' => '115',
-          'type' => '2831'
+          'type' => '344'
         },
         '33' => {
           'name' => 'nominal_value',
           'offset' => '118',
-          'type' => '91352'
+          'type' => '119138'
         },
         '34' => {
           'name' => 'normal_max',
           'offset' => '128',
-          'type' => '91352'
+          'type' => '119138'
         },
         '35' => {
           'name' => 'normal_min',
           'offset' => '132',
-          'type' => '91352'
+          'type' => '119138'
         },
         '36' => {
           'name' => 'warning_high',
           'offset' => '136',
-          'type' => '91352'
+          'type' => '119138'
         },
         '37' => {
           'name' => 'warning_low',
           'offset' => '146',
-          'type' => '91352'
+          'type' => '119138'
         },
         '38' => {
           'name' => 'critical_high',
           'offset' => '150',
-          'type' => '91352'
+          'type' => '119138'
         },
         '39' => {
           'name' => 'critical_low',
           'offset' => '256',
-          'type' => '91352'
+          'type' => '119138'
         },
         '40' => {
           'name' => 'fatal_high',
           'offset' => '260',
-          'type' => '91352'
+          'type' => '119138'
         },
         '41' => {
           'name' => 'fatal_low',
           'offset' => '264',
-          'type' => '91352'
+          'type' => '119138'
         }
       },
       'Name' => 'struct pldm_numeric_sensor_value_pdr',
       'Size' => '112',
       'Type' => 'Struct'
     },
-    '92675' => {
-      'BaseType' => '89599',
+    '120461' => {
+      'BaseType' => '117385',
       'Header' => 'platform.h',
       'Line' => '869',
       'Name' => 'pldm_utf16be',
       'Size' => '2',
       'Type' => 'Typedef'
     },
-    '92688' => {
+    '120474' => {
       'Header' => 'platform.h',
       'Line' => '871',
       'Memb' => {
         '0' => {
           'name' => 'tag',
           'offset' => '0',
-          'type' => '977'
+          'type' => '5631'
         },
         '1' => {
           'name' => 'name',
           'offset' => '8',
-          'type' => '92730'
+          'type' => '120516'
         }
       },
       'Name' => 'struct pldm_entity_auxiliary_name',
       'Size' => '16',
       'Type' => 'Struct'
     },
-    '92730' => {
-      'BaseType' => '92675',
+    '120516' => {
+      'BaseType' => '120461',
       'Name' => 'pldm_utf16be*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '92735' => {
+    '120521' => {
       'Header' => 'platform.h',
       'Line' => '881',
       'Memb' => {
         '0' => {
           'name' => 'hdr',
           'offset' => '0',
-          'type' => '91962'
+          'type' => '119748'
         },
         '1' => {
           'name' => 'container',
           'offset' => '18',
-          'type' => '60835'
+          'type' => '88585'
         },
         '2' => {
           'name' => 'shared_name_count',
           'offset' => '24',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'name_string_count',
           'offset' => '25',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'names',
           'offset' => '36',
-          'type' => '92849'
+          'type' => '120635'
         },
         '5' => {
           'name' => 'auxiliary_name_data_size',
           'offset' => '50',
-          'type' => '1140'
+          'type' => '164'
         },
         '6' => {
           'name' => 'auxiliary_name_data',
           'offset' => '64',
-          'type' => '92854'
+          'type' => '120640'
         }
       },
       'Name' => 'struct pldm_entity_auxiliary_names_pdr',
       'Size' => '40',
       'Type' => 'Struct'
     },
-    '92849' => {
-      'BaseType' => '92688',
+    '120635' => {
+      'BaseType' => '120474',
       'Name' => 'struct pldm_entity_auxiliary_name*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '92854' => {
-      'BaseType' => '114',
+    '120640' => {
+      'BaseType' => '128',
       'Name' => 'char[]',
       'Size' => '8',
       'Type' => 'Array'
     },
-    '92869' => {
+    '120655' => {
       'Header' => 'platform.h',
       'Line' => '911',
       'Memb' => {
         '0' => {
           'name' => 'state_set_id',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '1' => {
           'name' => 'possible_states_size',
           'offset' => '2',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'states',
           'offset' => '3',
-          'type' => '90983'
+          'type' => '118769'
         }
       },
       'Name' => 'struct state_effecter_possible_states',
       'Size' => '4',
       'Type' => 'Struct'
     },
-    '92926' => {
-      'BaseType' => '92869',
+    '120712' => {
+      'BaseType' => '120655',
       'Name' => 'struct state_effecter_possible_states const',
       'Size' => '4',
       'Type' => 'Const'
     },
-    '92931' => {
+    '120717' => {
       'Header' => 'platform.h',
       'Line' => '959',
       'Memb' => {
         '0' => {
           'name' => 'set_request',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'effecter_state',
           'offset' => '1',
-          'type' => '121'
+          'type' => '135'
         }
       },
       'Name' => 'struct state_field_for_state_effecter_set',
       'Size' => '2',
       'Type' => 'Struct'
     },
-    '92974' => {
-      'BaseType' => '92931',
+    '120760' => {
+      'BaseType' => '120717',
       'Header' => 'platform.h',
       'Line' => '962',
       'Name' => 'set_effecter_state_field',
       'Size' => '2',
       'Type' => 'Typedef'
     },
-    '92987' => {
+    '120773' => {
       'Header' => 'platform.h',
       'Line' => '968',
       'Memb' => {
         '0' => {
           'name' => 'sensor_op_state',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'present_state',
           'offset' => '1',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'previous_state',
           'offset' => '2',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'event_state',
           'offset' => '3',
-          'type' => '121'
+          'type' => '135'
         }
       },
       'Name' => 'struct state_field_for_get_state_sensor_readings',
       'Size' => '4',
       'Type' => 'Struct'
     },
-    '93058' => {
-      'BaseType' => '92987',
+    '120844' => {
+      'BaseType' => '120773',
       'Header' => 'platform.h',
       'Line' => '976',
       'Name' => 'get_sensor_state_field',
       'Size' => '4',
       'Type' => 'Typedef'
     },
-    '93071' => {
+    '120857' => {
       'Header' => 'platform.h',
       'Line' => '982',
       'Memb' => {
         '0' => {
           'name' => 'effecter_op_state',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'pending_state',
           'offset' => '1',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'present_state',
           'offset' => '2',
-          'type' => '121'
+          'type' => '135'
         }
       },
       'Name' => 'struct state_field_for_get_state_effecter_states',
       'Size' => '3',
       'Type' => 'Struct'
     },
-    '93128' => {
-      'BaseType' => '93071',
+    '120914' => {
+      'BaseType' => '120857',
       'Header' => 'platform.h',
       'Line' => '986',
       'Name' => 'get_effecter_state_field',
       'Size' => '3',
       'Type' => 'Typedef'
     },
-    '93857' => {
+    '121643' => {
       'Header' => 'platform.h',
       'Line' => '1131',
       'Memb' => {
         '0' => {
           'name' => 'completion_code',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'comp_effecter_count',
           'offset' => '1',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'field',
           'offset' => '2',
-          'type' => '93914'
+          'type' => '121700'
         }
       },
       'Name' => 'struct pldm_get_state_effecter_states_resp',
       'Size' => '26',
       'Type' => 'Struct'
     },
-    '93914' => {
-      'BaseType' => '93128',
+    '121700' => {
+      'BaseType' => '120914',
       'Name' => 'get_effecter_state_field[8]',
       'Size' => '24',
       'Type' => 'Array'
     },
-    '93930' => {
+    '121716' => {
       'Header' => 'platform.h',
       'Line' => '1141',
       'Memb' => {
         '0' => {
           'name' => 'sensor_id',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '1' => {
           'name' => 'sensor_event_class_type',
           'offset' => '2',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'event_class',
           'offset' => '3',
-          'type' => '3443'
+          'type' => '962'
         }
       },
       'Name' => 'struct pldm_sensor_event_data',
       'Size' => '4',
       'Type' => 'Struct'
     },
-    '94044' => {
+    '121830' => {
       'Header' => 'platform.h',
       'Line' => '1181',
       'Memb' => {
         '0' => {
           'name' => 'format_version',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'event_id',
           'offset' => '2',
-          'type' => '1006'
+          'type' => '5660'
         },
         '2' => {
           'name' => 'data_transfer_handle',
           'offset' => '4',
-          'type' => '1018'
+          'type' => '147'
         }
       },
       'Name' => 'struct pldm_message_poll_event',
       'Size' => '8',
       'Type' => 'Struct'
     },
-    '94106' => {
+    '121892' => {
       'Header' => 'platform.h',
       'Line' => '1191',
       'Memb' => {
         '0' => {
           'name' => 'format_version',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'format_type',
           'offset' => '1',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'event_data_length',
           'offset' => '2',
-          'type' => '1006'
+          'type' => '5660'
         },
         '3' => {
           'name' => 'event_data',
           'offset' => '4',
-          'type' => '94177'
+          'type' => '121963'
         }
       },
       'Name' => 'struct pldm_platform_cper_event',
       'Size' => '4',
       'Type' => 'Struct'
     },
-    '94177' => {
-      'BaseType' => '121',
+    '121963' => {
+      'BaseType' => '135',
       'Name' => 'uint8_t[]',
       'Size' => '8',
       'Type' => 'Array'
     },
-    '94333' => {
+    '122119' => {
       'Header' => 'platform.h',
       'Line' => '1251',
       'Memb' => {
         '0' => {
           'name' => 'event_data_format',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'number_of_change_records',
           'offset' => '1',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'change_records',
           'offset' => '2',
-          'type' => '3443'
+          'type' => '962'
         }
       },
       'Name' => 'struct pldm_pdr_repository_chg_event_data',
       'Size' => '3',
       'Type' => 'Struct'
     },
-    '94957' => {
-      'BaseType' => '94106',
+    '122743' => {
+      'BaseType' => '121892',
       'Name' => 'struct pldm_platform_cper_event*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '96710' => {
-      'BaseType' => '92735',
+    '124496' => {
+      'BaseType' => '120521',
       'Name' => 'struct pldm_entity_auxiliary_names_pdr*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '101961' => {
-      'BaseType' => '93857',
+    '129747' => {
+      'BaseType' => '121643',
       'Name' => 'struct pldm_get_state_effecter_states_resp*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '130179' => {
-      'BaseType' => '13426',
+    '157965' => {
+      'BaseType' => '2697',
       'Name' => 'size_t*const',
       'Size' => '8',
       'Type' => 'Const'
     },
-    '131891' => {
-      'BaseType' => '94044',
+    '159677' => {
+      'BaseType' => '121830',
       'Name' => 'struct pldm_message_poll_event*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '132885' => {
-      'BaseType' => '132895',
+    '160671' => {
+      'BaseType' => '160681',
       'Name' => 'uint32_t const*const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '132890' => {
-      'BaseType' => '30176',
+    '160676' => {
+      'BaseType' => '159',
       'Name' => 'uint32_t const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '132895' => {
-      'BaseType' => '132890',
+    '160681' => {
+      'BaseType' => '160676',
       'Name' => 'uint32_t const*const',
       'Size' => '8',
       'Type' => 'Const'
     },
-    '132900' => {
-      'BaseType' => '94333',
+    '160686' => {
+      'BaseType' => '122119',
       'Name' => 'struct pldm_pdr_repository_chg_event_data*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '160330' => {
-      'BaseType' => '92082',
+    '188116' => {
+      'BaseType' => '119868',
       'Name' => 'struct pldm_numeric_sensor_value_pdr*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '172713' => {
-      'BaseType' => '93930',
+    '200499' => {
+      'BaseType' => '121716',
       'Name' => 'struct pldm_sensor_event_data*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '172718' => {
-      'BaseType' => '172713',
+    '200504' => {
+      'BaseType' => '200499',
       'Name' => 'struct pldm_sensor_event_data*const',
       'Size' => '8',
       'Type' => 'Const'
     },
-    '174868' => {
-      'BaseType' => '93058',
+    '202654' => {
+      'BaseType' => '120844',
       'Name' => 'get_sensor_state_field*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '189586' => {
-      'BaseType' => '92974',
+    '217372' => {
+      'BaseType' => '120760',
       'Name' => 'set_effecter_state_field*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '190562' => {
-      'BaseType' => '90767',
+    '218348' => {
+      'BaseType' => '118553',
       'Name' => 'struct pldm_state_sensor_pdr*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '190567' => {
-      'BaseType' => '190562',
+    '218353' => {
+      'BaseType' => '218348',
       'Name' => 'struct pldm_state_sensor_pdr*const',
       'Size' => '8',
       'Type' => 'Const'
     },
-    '190572' => {
-      'BaseType' => '90978',
+    '218358' => {
+      'BaseType' => '118764',
       'Name' => 'struct state_sensor_possible_states const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '190577' => {
-      'BaseType' => '190572',
+    '218363' => {
+      'BaseType' => '218358',
       'Name' => 'struct state_sensor_possible_states const*const',
       'Size' => '8',
       'Type' => 'Const'
     },
-    '190972' => {
-      'BaseType' => '90999',
+    '218758' => {
+      'BaseType' => '118785',
       'Name' => 'struct pldm_state_effecter_pdr*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '190977' => {
-      'BaseType' => '190972',
+    '218763' => {
+      'BaseType' => '218758',
       'Name' => 'struct pldm_state_effecter_pdr*const',
       'Size' => '8',
       'Type' => 'Const'
     },
-    '190982' => {
-      'BaseType' => '92926',
+    '218768' => {
+      'BaseType' => '120712',
       'Name' => 'struct state_effecter_possible_states const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '190987' => {
-      'BaseType' => '190982',
+    '218773' => {
+      'BaseType' => '218768',
       'Name' => 'struct state_effecter_possible_states const*const',
       'Size' => '8',
       'Type' => 'Const'
     },
-    '193843' => {
+    '221629' => {
       'Line' => '19',
       'Memb' => {
         '0' => {
           'name' => 'prev',
           'offset' => '0',
-          'type' => '187'
+          'type' => '4841'
         },
         '1' => {
           'name' => 'allocations',
           'offset' => '4',
-          'type' => '1018'
+          'type' => '147'
         }
       },
       'Name' => 'struct pldm_tid_state',
@@ -13233,13 +13203,13 @@ $VAR1 = {
       'Source' => 'instance-id.c',
       'Type' => 'Struct'
     },
-    '193882' => {
+    '221668' => {
       'Line' => '24',
       'Memb' => {
         '0' => {
           'name' => 'state',
           'offset' => '0',
-          'type' => '193924'
+          'type' => '221710'
         },
         '1' => {
           'name' => 'lock_db_fd',
@@ -13253,53 +13223,53 @@ $VAR1 = {
       'Source' => 'instance-id.c',
       'Type' => 'Struct'
     },
-    '193924' => {
-      'BaseType' => '193843',
+    '221710' => {
+      'BaseType' => '221629',
       'Name' => 'struct pldm_tid_state[256]',
       'Size' => '2048',
       'Type' => 'Array'
     },
-    '194480' => {
-      'BaseType' => '193882',
+    '222266' => {
+      'BaseType' => '221668',
       'Name' => 'struct pldm_instance_db*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '194867' => {
-      'BaseType' => '187',
+    '222653' => {
+      'BaseType' => '4841',
       'Name' => 'pldm_instance_id_t*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '195043' => {
-      'BaseType' => '194480',
+    '222829' => {
+      'BaseType' => '222266',
       'Name' => 'struct pldm_instance_db**',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '195835' => {
-      'BaseType' => '121',
+    '223621' => {
+      'BaseType' => '135',
       'Header' => 'pldm.h',
       'Line' => '13',
       'Name' => 'mctp_eid_t',
       'Size' => '1',
       'Type' => 'Typedef'
     },
-    '195950' => {
-      'BaseType' => '284',
+    '223736' => {
+      'BaseType' => '4938',
       'Header' => 'pldm.h',
       'Line' => '30',
       'Name' => 'pldm_requester_rc_t',
       'Size' => '4',
       'Type' => 'Typedef'
     },
-    '195968' => {
+    '223754' => {
       'Line' => '26',
       'Memb' => {
         '0' => {
           'name' => 'transport',
           'offset' => '0',
-          'type' => '196041'
+          'type' => '223827'
         },
         '1' => {
           'name' => 'socket',
@@ -13309,12 +13279,12 @@ $VAR1 = {
         '2' => {
           'name' => 'tid_eid_map',
           'offset' => '68',
-          'type' => '199737'
+          'type' => '227532'
         },
         '3' => {
           'name' => 'socket_send_buf',
           'offset' => '768',
-          'type' => '198657'
+          'type' => '226445'
         }
       },
       'Name' => 'struct pldm_transport_mctp_demux',
@@ -13323,46 +13293,46 @@ $VAR1 = {
       'Source' => 'mctp-demux.c',
       'Type' => 'Struct'
     },
-    '195994' => {
-      'BaseType' => '195968',
+    '223780' => {
+      'BaseType' => '223754',
       'Name' => 'struct pldm_transport_mctp_demux*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '196036' => {
-      'BaseType' => '196041',
+    '223822' => {
+      'BaseType' => '223827',
       'Name' => 'struct pldm_transport*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '196041' => {
+    '223827' => {
       'Header' => 'transport.h',
       'Line' => '18',
       'Memb' => {
         '0' => {
           'name' => 'name',
           'offset' => '0',
-          'type' => '3999'
+          'type' => '8652'
         },
         '1' => {
           'name' => 'version',
           'offset' => '8',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'recv',
           'offset' => '22',
-          'type' => '198968'
+          'type' => '226758'
         },
         '3' => {
           'name' => 'send',
           'offset' => '36',
-          'type' => '199009'
+          'type' => '226799'
         },
         '4' => {
           'name' => 'init_pollfd',
           'offset' => '50',
-          'type' => '199089'
+          'type' => '226880'
         }
       },
       'Name' => 'struct pldm_transport',
@@ -13370,19 +13340,19 @@ $VAR1 = {
       'Size' => '40',
       'Type' => 'Struct'
     },
-    '196177' => {
-      'BaseType' => '175',
+    '223963' => {
+      'BaseType' => '4829',
       'Name' => 'pldm_tid_t*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '196280' => {
-      'BaseType' => '195994',
+    '224066' => {
+      'BaseType' => '223780',
       'Name' => 'struct pldm_transport_mctp_demux**',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '198377' => {
+    '226163' => {
       'BaseType' => '46',
       'Header' => 'int-ll64.h',
       'Line' => '21',
@@ -13391,7 +13361,7 @@ $VAR1 = {
       'Size' => '1',
       'Type' => 'Typedef'
     },
-    '198389' => {
+    '226175' => {
       'BaseType' => '53',
       'Header' => 'int-ll64.h',
       'Line' => '24',
@@ -13400,7 +13370,7 @@ $VAR1 = {
       'Size' => '2',
       'Type' => 'Typedef'
     },
-    '198657' => {
+    '226445' => {
       'Header' => 'socket.h',
       'Line' => '5',
       'Memb' => {
@@ -13425,53 +13395,53 @@ $VAR1 = {
       'Size' => '12',
       'Type' => 'Struct'
     },
-    '198968' => {
+    '226758' => {
       'Name' => 'pldm_requester_rc_t(*)(struct pldm_transport*, pldm_tid_t*, void**, size_t*)',
       'Param' => {
         '0' => {
-          'type' => '196036'
+          'type' => '223822'
         },
         '1' => {
-          'type' => '196177'
+          'type' => '223963'
         },
         '2' => {
-          'type' => '53604'
+          'type' => '80830'
         },
         '3' => {
-          'type' => '13426'
+          'type' => '2697'
         }
       },
-      'Return' => '195950',
+      'Return' => '223736',
       'Size' => '8',
       'Type' => 'FuncPtr'
     },
-    '199009' => {
+    '226799' => {
       'Name' => 'pldm_requester_rc_t(*)(struct pldm_transport*, pldm_tid_t, void const*, size_t)',
       'Param' => {
         '0' => {
-          'type' => '196036'
+          'type' => '223822'
         },
         '1' => {
-          'type' => '175'
+          'type' => '4829'
         },
         '2' => {
-          'type' => '2396'
+          'type' => '1262'
         },
         '3' => {
-          'type' => '1140'
+          'type' => '164'
         }
       },
-      'Return' => '195950',
+      'Return' => '223736',
       'Size' => '8',
       'Type' => 'FuncPtr'
     },
-    '199034' => {
-      'BaseType' => '199039',
+    '226824' => {
+      'BaseType' => '226829',
       'Name' => 'struct pollfd*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '199039' => {
+    '226829' => {
       'Header' => 'poll.h',
       'Line' => '36',
       'Memb' => {
@@ -13496,21 +13466,21 @@ $VAR1 = {
       'Size' => '8',
       'Type' => 'Struct'
     },
-    '199089' => {
+    '226880' => {
       'Name' => 'int(*)(struct pldm_transport*, struct pollfd*)',
       'Param' => {
         '0' => {
-          'type' => '196036'
+          'type' => '223822'
         },
         '1' => {
-          'type' => '199034'
+          'type' => '226824'
         }
       },
       'Return' => '100',
       'Size' => '8',
       'Type' => 'FuncPtr'
     },
-    '199094' => {
+    '226885' => {
       'BaseType' => '53',
       'Header' => 'socket.h',
       'Line' => '10',
@@ -13519,14 +13489,14 @@ $VAR1 = {
       'Size' => '2',
       'Type' => 'Typedef'
     },
-    '199471' => {
+    '227263' => {
       'Header' => 'mctp.h',
       'Line' => '18',
       'Memb' => {
         '0' => {
           'name' => 's_addr',
           'offset' => '0',
-          'type' => '195835'
+          'type' => '223621'
         }
       },
       'Name' => 'struct mctp_addr',
@@ -13534,19 +13504,19 @@ $VAR1 = {
       'Size' => '1',
       'Type' => 'Struct'
     },
-    '199497' => {
+    '227290' => {
       'Header' => 'mctp.h',
       'Line' => '22',
       'Memb' => {
         '0' => {
           'name' => 'smctp_family',
           'offset' => '0',
-          'type' => '199094'
+          'type' => '226885'
         },
         '1' => {
           'name' => '__smctp_pad0',
           'offset' => '2',
-          'type' => '198389'
+          'type' => '226175'
         },
         '2' => {
           'name' => 'smctp_network',
@@ -13556,22 +13526,22 @@ $VAR1 = {
         '3' => {
           'name' => 'smctp_addr',
           'offset' => '8',
-          'type' => '199471'
+          'type' => '227263'
         },
         '4' => {
           'name' => 'smctp_type',
           'offset' => '9',
-          'type' => '198377'
+          'type' => '226163'
         },
         '5' => {
           'name' => 'smctp_tag',
           'offset' => '16',
-          'type' => '198377'
+          'type' => '226163'
         },
         '6' => {
           'name' => '__smctp_pad1',
           'offset' => '17',
-          'type' => '198377'
+          'type' => '226163'
         }
       },
       'Name' => 'struct sockaddr_mctp',
@@ -13579,19 +13549,19 @@ $VAR1 = {
       'Size' => '12',
       'Type' => 'Struct'
     },
-    '199601' => {
-      'BaseType' => '199497',
+    '227395' => {
+      'BaseType' => '227290',
       'Name' => 'struct sockaddr_mctp const',
       'Size' => '12',
       'Type' => 'Const'
     },
-    '199644' => {
+    '227439' => {
       'Line' => '35',
       'Memb' => {
         '0' => {
           'name' => 'transport',
           'offset' => '0',
-          'type' => '196041'
+          'type' => '223827'
         },
         '1' => {
           'name' => 'socket',
@@ -13601,22 +13571,22 @@ $VAR1 = {
         '2' => {
           'name' => 'tid_eid_map',
           'offset' => '68',
-          'type' => '199737'
+          'type' => '227532'
         },
         '3' => {
           'name' => 'socket_send_buf',
           'offset' => '768',
-          'type' => '198657'
+          'type' => '226445'
         },
         '4' => {
           'name' => 'bound',
           'offset' => '786',
-          'type' => '805'
+          'type' => '5459'
         },
         '5' => {
           'name' => 'cookie_jar',
           'offset' => '800',
-          'type' => '199'
+          'type' => '4853'
         }
       },
       'Name' => 'struct pldm_transport_af_mctp',
@@ -13625,217 +13595,217 @@ $VAR1 = {
       'Source' => 'af-mctp.c',
       'Type' => 'Struct'
     },
-    '199737' => {
-      'BaseType' => '175',
+    '227532' => {
+      'BaseType' => '4829',
       'Name' => 'pldm_tid_t[256]',
       'Size' => '256',
       'Type' => 'Array'
     },
-    '200538' => {
-      'BaseType' => '199644',
+    '228333' => {
+      'BaseType' => '227439',
       'Name' => 'struct pldm_transport_af_mctp*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '200543' => {
-      'BaseType' => '199601',
+    '228338' => {
+      'BaseType' => '227395',
       'Name' => 'struct sockaddr_mctp const*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '200856' => {
-      'BaseType' => '200538',
+    '228651' => {
+      'BaseType' => '228333',
       'Name' => 'struct pldm_transport_af_mctp**',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '227501' => {
+    '255319' => {
       'Header' => 'file_io.h',
       'Line' => '32',
       'Memb' => {
         '0' => {
           'name' => 'handle',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'length',
           'offset' => '4',
-          'type' => '1018'
+          'type' => '147'
         },
         '2' => {
           'name' => 'data',
           'offset' => '8',
-          'type' => '94177'
+          'type' => '121963'
         }
       },
       'Name' => 'struct pldm_oem_meta_file_io_write_req',
       'Size' => '8',
       'Type' => 'Struct'
     },
-    '227568' => {
+    '255386' => {
       'Header' => 'file_io.h',
       'Line' => '45',
       'Memb' => {
         '0' => {
           'name' => 'transferFlag',
           'offset' => '0',
-          'type' => '121'
+          'type' => '135'
         },
         '1' => {
           'name' => 'offset',
           'offset' => '2',
-          'type' => '1006'
+          'type' => '5660'
         }
       },
       'Name' => 'struct pldm_oem_meta_file_io_read_data_info',
       'Size' => '4',
       'Type' => 'Struct'
     },
-    '227607' => {
+    '255425' => {
       'Header' => 'file_io.h',
       'Line' => '55',
       'Memb' => {
         '0' => {
           'name' => 'size',
           'offset' => '0',
-          'type' => '1006'
+          'type' => '5660'
         },
         '1' => {
           'name' => 'crc32',
           'offset' => '4',
-          'type' => '1018'
+          'type' => '147'
         }
       },
       'Name' => 'struct pldm_oem_meta_file_io_read_attr_info',
       'Size' => '8',
       'Type' => 'Struct'
     },
-    '227646' => {
+    '255464' => {
       'Header' => 'file_io.h',
       'Line' => '70',
       'Memb' => {
         '0' => {
           'name' => 'data',
           'offset' => '0',
-          'type' => '227568'
+          'type' => '255386'
         }
       },
       'Name' => 'anon-union-file_io.h-70',
       'Size' => '4',
       'Type' => 'Union'
     },
-    '227664' => {
+    '255482' => {
       'Header' => 'file_io.h',
       'Line' => '65',
       'Memb' => {
         '0' => {
           'name' => 'version',
           'offset' => '0',
-          'type' => '1140'
+          'type' => '164'
         },
         '1' => {
           'name' => 'handle',
           'offset' => '8',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'option',
           'offset' => '9',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'length',
           'offset' => '16',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'info',
           'offset' => '18',
-          'type' => '227646'
+          'type' => '255464'
         }
       },
       'Name' => 'struct pldm_oem_meta_file_io_read_req',
       'Size' => '16',
       'Type' => 'Struct'
     },
-    '227742' => {
+    '255560' => {
       'Header' => 'file_io.h',
       'Line' => '86',
       'Memb' => {
         '0' => {
           'name' => 'attr',
           'offset' => '0',
-          'type' => '227607'
+          'type' => '255425'
         },
         '1' => {
           'name' => 'data',
           'offset' => '0',
-          'type' => '227568'
+          'type' => '255386'
         }
       },
       'Name' => 'anon-union-file_io.h-86',
       'Size' => '8',
       'Type' => 'Union'
     },
-    '227770' => {
+    '255588' => {
       'Header' => 'file_io.h',
       'Line' => '80',
       'Memb' => {
         '0' => {
           'name' => 'version',
           'offset' => '0',
-          'type' => '1140'
+          'type' => '164'
         },
         '1' => {
           'name' => 'completion_code',
           'offset' => '8',
-          'type' => '121'
+          'type' => '135'
         },
         '2' => {
           'name' => 'handle',
           'offset' => '9',
-          'type' => '121'
+          'type' => '135'
         },
         '3' => {
           'name' => 'option',
           'offset' => '16',
-          'type' => '121'
+          'type' => '135'
         },
         '4' => {
           'name' => 'length',
           'offset' => '17',
-          'type' => '121'
+          'type' => '135'
         },
         '5' => {
           'name' => 'info',
           'offset' => '18',
-          'type' => '227742'
+          'type' => '255560'
         },
         '6' => {
           'name' => 'data',
           'offset' => '32',
-          'type' => '94177'
+          'type' => '121963'
         }
       },
       'Name' => 'struct pldm_oem_meta_file_io_read_resp',
       'Size' => '24',
       'Type' => 'Struct'
     },
-    '230271' => {
-      'BaseType' => '227770',
+    '258089' => {
+      'BaseType' => '255588',
       'Name' => 'struct pldm_oem_meta_file_io_read_resp*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '231400' => {
-      'BaseType' => '227664',
+    '259218' => {
+      'BaseType' => '255482',
       'Name' => 'struct pldm_oem_meta_file_io_read_req*',
       'Size' => '8',
       'Type' => 'Pointer'
     },
-    '231836' => {
-      'BaseType' => '227501',
+    '259654' => {
+      'BaseType' => '255319',
       'Name' => 'struct pldm_oem_meta_file_io_write_req*',
       'Size' => '8',
       'Type' => 'Pointer'

--- a/docs/checklists/changes.md
+++ b/docs/checklists/changes.md
@@ -46,6 +46,12 @@
 [command-center-byte-order-fallacy]:
   https://commandcenter.blogspot.com/2012/04/byte-order-fallacy.html
 
+- [what’s the most annoying thing about writing C - Jessica
+  Paquette][barrelshifter-annoying-c]
+
+[barrelshifter-annoying-c]:
+  https://mastodon.social/@barrelshifter/114016810912730423
+
 ## References
 
 - [The C programming language - C Standards Committee][c-language]

--- a/docs/checklists/changes.md
+++ b/docs/checklists/changes.md
@@ -52,6 +52,12 @@
 [barrelshifter-annoying-c]:
   https://mastodon.social/@barrelshifter/114016810912730423
 
+- [The Power of Ten: Rules for Developing Safety Critical Code - NASA/JPL
+  Laboratory for Reliable Software][nasa-reliable-code]
+
+[nasa-reliable-code]:
+  https://www.cs.otago.ac.nz/cosc345/resources/nasa-10-rules.pdf
+
 ## References
 
 - [The C programming language - C Standards Committee][c-language]

--- a/docs/checklists/changes.md
+++ b/docs/checklists/changes.md
@@ -48,10 +48,9 @@
 
 ## References
 
-- [C17 draft standard][c17-draft-standard]
+- [The C programming language - C Standards Committee][c-language]
 
-[c17-draft-standard]:
-  https://web.archive.org/web/20181230041359if_/http://www.open-std.org/jtc1/sc22/wg14/www/abq/c17_updated_proposed_fdis.pdf
+[c-language]: https://www.c-language.org/
 
 - [SEI CERT C Coding Standard][sei-cert-c-coding-standard]
 

--- a/include/libpldm/base.h
+++ b/include/libpldm/base.h
@@ -112,6 +112,7 @@ typedef enum {
 #define PLDM_GET_TYPES_RESP_BYTES    9
 #define PLDM_GET_TID_REQ_BYTES	     0
 #define PLDM_GET_TID_RESP_BYTES	     2
+#define PLDM_SET_TID_REQ_BYTES	     1
 #define PLDM_SET_TID_RESP_BYTES	     1
 #define PLDM_GET_COMMANDS_RESP_BYTES 33
 /* Response data has only one version and does not contain the checksum */

--- a/include/libpldm/pdr.h
+++ b/include/libpldm/pdr.h
@@ -234,6 +234,18 @@ int pldm_pdr_find_child_container_id_index_range_exclude(
 	uint8_t child_index, uint32_t range_exclude_start_handle,
 	uint32_t range_exclude_end_handle, uint16_t *container_id);
 
+/** @brief Delete record using its record handle
+ *
+ *  @param[in] repo - opaque pointer acting as a PDR repo handle
+ *  @param[in] record_handle - record handle of input PDR record
+ *  @param[in] is_remote - if true, then the PDR is not from this terminus
+ *
+ *  @return 0 if deleted successful else returns -EINVAL when repo is NULL
+ *  or -ENOENT if the record handle is not found in the repo.
+ */
+int pldm_pdr_delete_by_record_handle(pldm_pdr *repo, uint32_t record_handle,
+				     bool is_remote);
+
 /* ======================= */
 /* FRU Record Set PDR APIs */
 /* ======================= */

--- a/meson.build
+++ b/meson.build
@@ -74,6 +74,34 @@ libpldm_include_dir = include_directories('include', is_system: true)
 subdir('include')
 subdir('src')
 
+doxygen = find_program('doxygen', required: false)
+if doxygen.found()
+    doxydata = configuration_data()
+    doxydata.set('description', meson.project_name())
+    doxydata.set('project', meson.project_name())
+    doxydata.set('version', meson.project_version())
+    doxydata.set(
+        'sources',
+        '@0@ @1@'.format(
+            meson.project_source_root() / 'include',
+            meson.project_source_root() / 'src',
+        ),
+    )
+    doxyfile = configure_file(
+        input: 'Doxyfile.in',
+        output: 'Doxyfile',
+        configuration: doxydata,
+        install: false,
+    )
+
+    docs = custom_target(
+        'docs',
+        input: doxyfile,
+        output: 'doxygen',
+        command: [doxygen, doxyfile],
+    )
+endif
+
 if get_option('tests')
     subdir('tests')
 endif

--- a/scripts/pre-submit
+++ b/scripts/pre-submit
@@ -26,7 +26,7 @@ fi
 # Ensure the test suite passes in the default configuration. Note
 # that we don't specify -Dabi=... - the default is equivalent to
 # -Dabi=deprecated,stable,testing.
-CFLAGS=-fanalyzer meson setup -Dabi-compliance-check=false "$BUILD"
+CC=gcc CXX=g++ CFLAGS=-fanalyzer meson setup -Dabi-compliance-check=false "$BUILD"
 meson compile -C "$BUILD"
 meson test -C "$BUILD"
 

--- a/src/dsp/firmware_update.c
+++ b/src/dsp/firmware_update.c
@@ -544,7 +544,7 @@ int decode_pldm_descriptor_from_iter(struct pldm_descriptor_iter *iter,
 	pldm_msgbuf_span_remaining(buf, (void **)&iter->field->ptr,
 				   &iter->field->length);
 
-	return pldm_msgbuf_destroy(buf);
+	return pldm_msgbuf_complete(buf);
 }
 
 static int decode_descriptor_type_length_value_errno(
@@ -867,7 +867,7 @@ int encode_query_device_identifiers_resp(
 		}
 	}
 
-	return pldm_msgbuf_destroy_used(buf, *payload_length, payload_length);
+	return pldm_msgbuf_complete_used(buf, *payload_length, payload_length);
 }
 
 LIBPLDM_ABI_STABLE
@@ -1041,7 +1041,7 @@ int encode_get_firmware_parameters_resp(
 	/* Further calls to encode_get_firmware_parameters_resp_comp_entry
 	 * will populate the remainder */
 
-	return pldm_msgbuf_destroy_used(buf, *payload_length, payload_length);
+	return pldm_msgbuf_complete_used(buf, *payload_length, payload_length);
 }
 
 LIBPLDM_ABI_TESTING
@@ -1102,7 +1102,7 @@ int encode_get_firmware_parameters_resp_comp_entry(
 		return rc;
 	}
 
-	return pldm_msgbuf_destroy_used(buf, *payload_length, payload_length);
+	return pldm_msgbuf_complete_used(buf, *payload_length, payload_length);
 }
 
 LIBPLDM_ABI_STABLE
@@ -1242,7 +1242,7 @@ int decode_query_downstream_devices_resp(
 	pldm_msgbuf_extract(buf, resp_data->max_number_of_downstream_devices);
 	pldm_msgbuf_extract(buf, resp_data->capabilities.value);
 
-	return pldm_msgbuf_destroy_consumed(buf);
+	return pldm_msgbuf_complete_consumed(buf);
 }
 
 LIBPLDM_ABI_STABLE
@@ -1286,7 +1286,7 @@ int encode_query_downstream_identifiers_req(
 	// Data correctness has been verified, cast it to 1-byte data directly.
 	pldm_msgbuf_insert(buf, params_req->transfer_operation_flag);
 
-	return pldm_msgbuf_destroy(buf);
+	return pldm_msgbuf_complete(buf);
 }
 
 LIBPLDM_ABI_STABLE
@@ -1338,7 +1338,7 @@ int decode_query_downstream_identifiers_resp(
 		return rc;
 	}
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return rc;
 	}
@@ -1375,7 +1375,7 @@ int decode_pldm_downstream_device_from_iter(
 	pldm_msgbuf_span_remaining(buf, (void **)&iter->field.ptr,
 				   &iter->field.length);
 
-	return pldm_msgbuf_destroy(buf);
+	return pldm_msgbuf_complete(buf);
 }
 
 LIBPLDM_ABI_STABLE
@@ -1419,7 +1419,7 @@ int encode_get_downstream_firmware_parameters_req(
 	// Data correctness has been verified, cast it to 1-byte data directly.
 	pldm_msgbuf_insert(buf, params_req->transfer_operation_flag);
 
-	return pldm_msgbuf_destroy(buf);
+	return pldm_msgbuf_complete(buf);
 }
 
 LIBPLDM_ABI_STABLE
@@ -1468,7 +1468,7 @@ int decode_get_downstream_firmware_parameters_resp(
 		return rc;
 	}
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return rc;
 	}
@@ -1668,7 +1668,7 @@ int decode_request_update_req(const struct pldm_msg *msg, size_t payload_length,
 		return rc;
 	}
 
-	return pldm_msgbuf_destroy_consumed(buf);
+	return pldm_msgbuf_complete_consumed(buf);
 }
 
 LIBPLDM_ABI_STABLE
@@ -1736,7 +1736,7 @@ int encode_request_update_resp(uint8_t instance_id,
 
 	/* TODO: DSP0267 1.3.0 adds GetPackageDataMaximumTransferSize */
 
-	return pldm_msgbuf_destroy_used(buf, *payload_length, payload_length);
+	return pldm_msgbuf_complete_used(buf, *payload_length, payload_length);
 }
 
 LIBPLDM_ABI_STABLE
@@ -1842,7 +1842,7 @@ int decode_pass_component_table_req(
 		return rc;
 	}
 
-	return pldm_msgbuf_destroy_consumed(buf);
+	return pldm_msgbuf_complete_consumed(buf);
 }
 
 LIBPLDM_ABI_STABLE
@@ -1912,7 +1912,7 @@ int encode_pass_component_table_resp(
 	pldm_msgbuf_insert(buf, resp_data->comp_resp);
 	pldm_msgbuf_insert(buf, resp_data->comp_resp_code);
 
-	return pldm_msgbuf_destroy_used(buf, *payload_length, payload_length);
+	return pldm_msgbuf_complete_used(buf, *payload_length, payload_length);
 }
 
 LIBPLDM_ABI_STABLE
@@ -2103,7 +2103,7 @@ int encode_update_component_resp(
 	pldm_msgbuf_insert(buf, resp_data->update_option_flags_enabled.value);
 	pldm_msgbuf_insert(buf, resp_data->time_before_req_fw_data);
 
-	return pldm_msgbuf_destroy_used(buf, *payload_length, payload_length);
+	return pldm_msgbuf_complete_used(buf, *payload_length, payload_length);
 }
 
 LIBPLDM_ABI_STABLE
@@ -2157,7 +2157,7 @@ int encode_request_firmware_data_req(
 	pldm_msgbuf_insert(buf, req_params->offset);
 	pldm_msgbuf_insert(buf, req_params->length);
 
-	return pldm_msgbuf_destroy_used(buf, *payload_length, payload_length);
+	return pldm_msgbuf_complete_used(buf, *payload_length, payload_length);
 }
 
 LIBPLDM_ABI_STABLE
@@ -2230,7 +2230,7 @@ int encode_transfer_complete_req(uint8_t instance_id, uint8_t transfer_result,
 		return rc;
 	}
 
-	return pldm_msgbuf_destroy_used(buf, *payload_length, payload_length);
+	return pldm_msgbuf_complete_used(buf, *payload_length, payload_length);
 }
 
 LIBPLDM_ABI_STABLE
@@ -2304,7 +2304,7 @@ int encode_verify_complete_req(uint8_t instance_id, uint8_t verify_result,
 		return rc;
 	}
 
-	return pldm_msgbuf_destroy_used(buf, *payload_length, payload_length);
+	return pldm_msgbuf_complete_used(buf, *payload_length, payload_length);
 }
 
 LIBPLDM_ABI_STABLE
@@ -2391,7 +2391,7 @@ int encode_apply_complete_req(uint8_t instance_id,
 	pldm_msgbuf_insert(
 		buf, req_data->comp_activation_methods_modification.value);
 
-	return pldm_msgbuf_destroy_used(buf, *payload_length, payload_length);
+	return pldm_msgbuf_complete_used(buf, *payload_length, payload_length);
 }
 
 LIBPLDM_ABI_STABLE
@@ -2543,7 +2543,7 @@ int encode_activate_firmware_resp(
 	pldm_msgbuf_insert_uint8(buf, PLDM_SUCCESS);
 	pldm_msgbuf_insert(buf, resp_data->estimated_time_activation);
 
-	return pldm_msgbuf_destroy_used(buf, *payload_length, payload_length);
+	return pldm_msgbuf_complete_used(buf, *payload_length, payload_length);
 }
 
 LIBPLDM_ABI_STABLE
@@ -2675,7 +2675,7 @@ int encode_get_status_resp(uint8_t instance_id,
 	pldm_msgbuf_insert(buf, status->reason_code);
 	pldm_msgbuf_insert(buf, status->update_option_flags_enabled.value);
 
-	return pldm_msgbuf_destroy_used(buf, *payload_length, payload_length);
+	return pldm_msgbuf_complete_used(buf, *payload_length, payload_length);
 }
 
 LIBPLDM_ABI_STABLE
@@ -2814,5 +2814,5 @@ int encode_cancel_update_resp(uint8_t instance_id,
 			   resp_data->non_functioning_component_indication);
 	pldm_msgbuf_insert(buf, resp_data->non_functioning_component_bitmap);
 
-	return pldm_msgbuf_destroy_used(buf, *payload_length, payload_length);
+	return pldm_msgbuf_complete_used(buf, *payload_length, payload_length);
 }

--- a/src/dsp/firmware_update.c
+++ b/src/dsp/firmware_update.c
@@ -1392,13 +1392,6 @@ int encode_get_downstream_firmware_parameters_req(
 		return -EINVAL;
 	}
 
-	rc = pldm_msgbuf_init_errno(
-		buf, PLDM_GET_DOWNSTREAM_FIRMWARE_PARAMETERS_REQ_BYTES,
-		msg->payload, payload_length);
-	if (rc < 0) {
-		return rc;
-	}
-
 	if (!is_transfer_operation_flag_valid(
 		    (enum transfer_op_flag)
 			    params_req->transfer_operation_flag)) {
@@ -1411,6 +1404,13 @@ int encode_get_downstream_firmware_parameters_req(
 	header.pldm_type = PLDM_FWUP;
 	header.command = PLDM_QUERY_DOWNSTREAM_FIRMWARE_PARAMETERS;
 	rc = pack_pldm_header_errno(&header, &msg->hdr);
+	if (rc < 0) {
+		return rc;
+	}
+
+	rc = pldm_msgbuf_init_errno(
+		buf, PLDM_GET_DOWNSTREAM_FIRMWARE_PARAMETERS_REQ_BYTES,
+		msg->payload, payload_length);
 	if (rc < 0) {
 		return rc;
 	}

--- a/src/dsp/pdr.c
+++ b/src/dsp/pdr.c
@@ -795,14 +795,14 @@ bool pldm_is_current_parent_child(pldm_entity_node *parent, pldm_entity *node)
 	return false;
 }
 
-static int entity_association_pdr_add_children(
+static int64_t entity_association_pdr_add_children(
 	pldm_entity_node *curr, pldm_pdr *repo, uint16_t size,
 	uint8_t contained_count, uint8_t association_type, bool is_remote,
 	uint16_t terminus_handle, uint32_t record_handle)
 {
 	uint8_t *start;
 	uint8_t *pdr;
-	int rc;
+	int64_t rc;
 
 	pdr = calloc(1, size);
 	if (!pdr) {
@@ -851,19 +851,26 @@ static int entity_association_pdr_add_children(
 	rc = pldm_pdr_add(repo, pdr, size, is_remote, terminus_handle,
 			  &record_handle);
 	free(pdr);
-	return rc;
+	return (rc < 0) ? rc : record_handle;
 }
 
-static int entity_association_pdr_add_entry(pldm_entity_node *curr,
-					    pldm_pdr *repo, bool is_remote,
-					    uint16_t terminus_handle,
-					    uint32_t record_handle)
+static int64_t entity_association_pdr_add_entry(pldm_entity_node *curr,
+						pldm_pdr *repo, bool is_remote,
+						uint16_t terminus_handle,
+						uint32_t record_handle)
 {
 	uint8_t num_logical_children = pldm_entity_get_num_children(
 		curr, PLDM_ENTITY_ASSOCIAION_LOGICAL);
 	uint8_t num_physical_children = pldm_entity_get_num_children(
 		curr, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
-	int rc;
+	int64_t rc;
+
+	if (!num_logical_children && !num_physical_children) {
+		if (record_handle == 0) {
+			return -EINVAL;
+		}
+		return record_handle - 1;
+	}
 
 	if (num_logical_children) {
 		uint16_t logical_pdr_size =
@@ -877,6 +884,12 @@ static int entity_association_pdr_add_entry(pldm_entity_node *curr,
 			terminus_handle, record_handle);
 		if (rc < 0) {
 			return rc;
+		}
+		if (num_physical_children) {
+			if (rc >= UINT32_MAX) {
+				return -EOVERFLOW;
+			}
+			record_handle = rc + 1;
 		}
 	}
 
@@ -893,9 +906,10 @@ static int entity_association_pdr_add_entry(pldm_entity_node *curr,
 		if (rc < 0) {
 			return rc;
 		}
+		record_handle = rc;
 	}
 
-	return 0;
+	return record_handle;
 }
 
 static bool is_present(pldm_entity entity, pldm_entity **entities,
@@ -914,36 +928,56 @@ static bool is_present(pldm_entity entity, pldm_entity **entities,
 	return false;
 }
 
-static int entity_association_pdr_add(pldm_entity_node *curr, pldm_pdr *repo,
-				      pldm_entity **entities,
-				      size_t num_entities, bool is_remote,
-				      uint16_t terminus_handle,
-				      uint32_t record_handle)
+static int64_t entity_association_pdr_add(pldm_entity_node *curr,
+					  pldm_pdr *repo,
+					  pldm_entity **entities,
+					  size_t num_entities, bool is_remote,
+					  uint16_t terminus_handle,
+					  uint32_t record_handle)
 {
-	int rc;
+	int64_t rc;
 
 	if (curr == NULL) {
-		return 0;
+		// entity_association_pdr_add function gets called
+		// recursively for the siblings and children of the
+		// entity. This causes NULL current entity node, and the
+		// record handle is returned
+		return record_handle;
 	}
 
 	if (is_present(curr->entity, entities, num_entities)) {
 		rc = entity_association_pdr_add_entry(
 			curr, repo, is_remote, terminus_handle, record_handle);
-		if (rc) {
+		if (rc < 0) {
 			return rc;
 		}
+		if (rc >= UINT32_MAX) {
+			return -EOVERFLOW;
+		}
+		record_handle = rc + 1;
 	}
 
 	rc = entity_association_pdr_add(curr->next_sibling, repo, entities,
 					num_entities, is_remote,
 					terminus_handle, record_handle);
-	if (rc) {
+	if (rc < 0) {
 		return rc;
 	}
+	// entity_association_pdr_add return record handle in success
+	// case. If the pdr gets added to the repo, new record handle
+	// will be returned. Below check confirms if the pdr is added
+	// to the repo and increments the record handle
+	if (record_handle != rc) {
+		if (rc >= UINT32_MAX) {
+			return -EOVERFLOW;
+		}
+		record_handle = rc + 1;
+	}
 
-	return entity_association_pdr_add(curr->first_child, repo, entities,
-					  num_entities, is_remote,
-					  terminus_handle, record_handle);
+	rc = entity_association_pdr_add(curr->first_child, repo, entities,
+					num_entities, is_remote,
+					terminus_handle, record_handle);
+	return rc;
 }
 
 LIBPLDM_ABI_STABLE
@@ -954,9 +988,10 @@ int pldm_entity_association_pdr_add(pldm_entity_association_tree *tree,
 	if (!tree || !repo) {
 		return 0;
 	}
-
-	return entity_association_pdr_add(tree->root, repo, NULL, 0, is_remote,
-					  terminus_handle, 0);
+	int64_t rc = entity_association_pdr_add(tree->root, repo, NULL, 0,
+						is_remote, terminus_handle, 0);
+	assert(rc >= INT_MIN);
+	return (rc < 0) ? (int)rc : 0;
 }
 
 LIBPLDM_ABI_STABLE
@@ -979,9 +1014,12 @@ int pldm_entity_association_pdr_add_from_node_with_record_handle(
 		return -EINVAL;
 	}
 
-	return entity_association_pdr_add(node, repo, entities, num_entities,
-					  is_remote, terminus_handle,
-					  record_handle);
+	int64_t rc = entity_association_pdr_add(node, repo, entities,
+						num_entities, is_remote,
+						terminus_handle, record_handle);
+
+	assert(rc >= INT_MIN);
+	return (rc < 0) ? (int)rc : 0;
 }
 
 static void find_entity_ref_in_tree(pldm_entity_node *tree_node,
@@ -1343,21 +1381,26 @@ void pldm_entity_association_pdr_extract(const uint8_t *pdr, uint16_t pdr_len,
 	    sizeof(struct pldm_pdr_entity_association)) {
 		return;
 	}
+
 	struct pldm_pdr_entity_association *entity_association_pdr =
 		(struct pldm_pdr_entity_association *)start;
 
-	if (entity_association_pdr->num_children == UINT8_MAX) {
+	size_t l_num_entities = entity_association_pdr->num_children;
+
+	if (l_num_entities == 0) {
 		return;
 	}
 
-	size_t l_num_entities = entity_association_pdr->num_children + 1;
-	if (l_num_entities < 2) {
+	if ((pdr_len - sizeof(struct pldm_pdr_hdr)) / sizeof(pldm_entity) <
+	    l_num_entities) {
 		return;
 	}
 
-	if (UINT8_MAX < l_num_entities) {
+	if (l_num_entities >= (size_t)UINT8_MAX) {
 		return;
 	}
+
+	l_num_entities++;
 
 	pldm_entity *l_entities = calloc(l_num_entities, sizeof(pldm_entity));
 	if (!l_entities) {

--- a/src/dsp/pdr.c
+++ b/src/dsp/pdr.c
@@ -487,7 +487,7 @@ int pldm_pdr_delete_by_record_handle(pldm_pdr *repo, uint32_t record_handle,
 			prev = pldm_pdr_get_prev_record(repo, record);
 			return pldm_pdr_remove_record(repo, record, prev);
 		}
-		rc = pldm_msgbuf_destroy(buf);
+		rc = pldm_msgbuf_complete(buf);
 		if (rc) {
 			return rc;
 		}
@@ -1641,7 +1641,7 @@ int pldm_entity_association_pdr_add_contained_entity_to_remote_pdr(
 	}
 
 	// Add new contained entity as a child of new PDR
-	rc = pldm_msgbuf_destroy(src);
+	rc = pldm_msgbuf_complete(src);
 	if (rc) {
 		goto cleanup_new_record_data;
 	}
@@ -1654,11 +1654,11 @@ int pldm_entity_association_pdr_add_contained_entity_to_remote_pdr(
 	pldm_msgbuf_copy(dst, src, uint16_t, child_entity_instance_num);
 	pldm_msgbuf_copy(dst, src, uint16_t, child_entity_container_id);
 
-	rc = pldm_msgbuf_destroy(src);
+	rc = pldm_msgbuf_complete(src);
 	if (rc) {
 		goto cleanup_new_record_data;
 	}
-	rc = pldm_msgbuf_destroy(dst);
+	rc = pldm_msgbuf_complete(dst);
 	if (rc) {
 		goto cleanup_new_record_data;
 	}
@@ -1791,15 +1791,15 @@ int pldm_entity_association_pdr_create_new(pldm_pdr *repo,
 	container_id = htole16(container_id);
 	memcpy(container_id_addr, &container_id, sizeof(uint16_t));
 
-	rc = pldm_msgbuf_destroy(dst);
+	rc = pldm_msgbuf_complete(dst);
 	if (rc) {
 		goto cleanup_new_record_data;
 	}
-	rc = pldm_msgbuf_destroy(src_p);
+	rc = pldm_msgbuf_complete(src_p);
 	if (rc) {
 		goto cleanup_new_record_data;
 	}
-	rc = pldm_msgbuf_destroy(src_c);
+	rc = pldm_msgbuf_complete(src_c);
 	if (rc) {
 		goto cleanup_new_record_data;
 	}
@@ -1878,7 +1878,7 @@ static int pldm_entity_association_find_record_handle_by_entity(
 			}
 		}
 	cleanup:
-		rc = pldm_msgbuf_destroy(dst);
+		rc = pldm_msgbuf_complete(dst);
 		if (rc) {
 			return rc;
 		}
@@ -2006,8 +2006,8 @@ int pldm_entity_association_pdr_remove_contained_entity(
 		pldm_msgbuf_insert(dst, e.entity_container_id);
 	}
 
-	if ((rc = pldm_msgbuf_destroy(src)) ||
-	    (rc = pldm_msgbuf_destroy(dst)) ||
+	if ((rc = pldm_msgbuf_complete(src)) ||
+	    (rc = pldm_msgbuf_complete(dst)) ||
 	    (rc = pldm_pdr_replace_record(repo, record, prev, new_record))) {
 		goto cleanup_new_record_data;
 	}
@@ -2079,7 +2079,7 @@ static int pldm_pdr_record_matches_fru_rsi(const pldm_pdr_record *record,
 	pldm_msgbuf_span_required(dst, skip_data_size, (void **)&skip_data);
 	pldm_msgbuf_extract(dst, record_fru_rsi);
 
-	rc = pldm_msgbuf_destroy(dst);
+	rc = pldm_msgbuf_complete(dst);
 	if (rc) {
 		return rc;
 	}
@@ -2166,7 +2166,7 @@ int pldm_pdr_remove_fru_record_set_by_rsi(pldm_pdr *repo, uint16_t fru_rsi,
 			return pldm_pdr_remove_record(repo, record, prev);
 		}
 	cleanup:
-		rc = pldm_msgbuf_destroy(buf);
+		rc = pldm_msgbuf_complete(buf);
 		if (rc) {
 			return rc;
 		}

--- a/src/dsp/pdr.c
+++ b/src/dsp/pdr.c
@@ -456,6 +456,46 @@ int pldm_pdr_find_child_container_id_index_range_exclude(
 	return -ENOENT;
 }
 
+LIBPLDM_ABI_TESTING
+int pldm_pdr_delete_by_record_handle(pldm_pdr *repo, uint32_t record_handle,
+				     bool is_remote)
+{
+	pldm_pdr_record *record;
+	pldm_pdr_record *prev = NULL;
+	int rc = 0;
+	uint16_t rec_handle = 0;
+
+	if (!repo) {
+		return -EINVAL;
+	}
+	record = repo->first;
+
+	while (record != NULL) {
+		struct pldm_msgbuf _buf;
+		struct pldm_msgbuf *buf = &_buf;
+		rc = pldm_msgbuf_init_errno(buf, sizeof(struct pldm_pdr_hdr),
+					    record->data, record->size);
+
+		if (rc) {
+			return rc;
+		}
+		if ((rc = pldm_msgbuf_extract(buf, rec_handle))) {
+			return rc;
+		}
+		if (record->is_remote == is_remote &&
+		    rec_handle == record_handle) {
+			prev = pldm_pdr_get_prev_record(repo, record);
+			return pldm_pdr_remove_record(repo, record, prev);
+		}
+		rc = pldm_msgbuf_destroy(buf);
+		if (rc) {
+			return rc;
+		}
+		record = record->next;
+	}
+	return -ENOENT;
+}
+
 typedef struct pldm_entity_association_tree {
 	pldm_entity_node *root;
 	uint16_t last_used_container_id;

--- a/src/dsp/platform.c
+++ b/src/dsp/platform.c
@@ -298,7 +298,7 @@ int decode_set_state_effecter_states_req(const struct pldm_msg *msg,
 		pldm_msgbuf_extract(buf, field[i].effecter_state);
 	}
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -338,7 +338,7 @@ int decode_get_pdr_req(const struct pldm_msg *msg, size_t payload_length,
 	pldm_msgbuf_extract_p(buf, request_cnt);
 	pldm_msgbuf_extract_p(buf, record_chg_num);
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -499,7 +499,7 @@ int decode_get_pdr_repository_info_resp(
 	pldm_msgbuf_extract_p(buf, largest_record_size);
 	pldm_msgbuf_extract_p(buf, data_transfer_handle_timeout);
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -559,7 +559,7 @@ int decode_get_pdr_repository_info_resp_safe(
 	pldm_msgbuf_extract(buf, resp->largest_record_size);
 	pldm_msgbuf_extract(buf, resp->data_transfer_handle_timeout);
 
-	return pldm_msgbuf_destroy_consumed(buf);
+	return pldm_msgbuf_complete_consumed(buf);
 }
 
 LIBPLDM_ABI_STABLE
@@ -655,7 +655,7 @@ int decode_get_pdr_resp(const struct pldm_msg *msg, size_t payload_length,
 		pldm_msgbuf_extract_p(buf, transfer_crc);
 	}
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -713,7 +713,7 @@ int decode_get_pdr_resp_safe(const struct pldm_msg *msg, size_t payload_length,
 		pldm_msgbuf_extract_p(buf, transfer_crc);
 	}
 
-	return pldm_msgbuf_destroy_consumed(buf);
+	return pldm_msgbuf_complete_consumed(buf);
 }
 
 LIBPLDM_ABI_STABLE
@@ -752,7 +752,7 @@ int decode_set_numeric_effecter_value_req(const struct pldm_msg *msg,
 	pldm_msgbuf_extract_effecter_value(buf, *effecter_data_size,
 					   effecter_value);
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -990,7 +990,7 @@ int decode_get_state_sensor_readings_resp(const struct pldm_msg *msg,
 		pldm_msgbuf_extract(buf, field[i].event_state);
 	}
 
-	rc = pldm_msgbuf_destroy_consumed(buf);
+	rc = pldm_msgbuf_complete_consumed(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -1024,7 +1024,7 @@ int decode_get_state_sensor_readings_req(const struct pldm_msg *msg,
 	pldm_msgbuf_extract(buf, sensor_rearm->byte);
 	pldm_msgbuf_extract_p(buf, reserved);
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -1095,7 +1095,7 @@ int decode_platform_event_message_req(const struct pldm_msg *msg,
 	pldm_msgbuf_extract_p(buf, tid);
 	pldm_msgbuf_extract_p(buf, event_class);
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -1168,7 +1168,7 @@ int decode_poll_for_platform_event_message_req(
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -1256,7 +1256,7 @@ int encode_poll_for_platform_event_message_resp(
 			return PLDM_ERROR_INVALID_LENGTH;
 		}
 
-		rc = pldm_msgbuf_destroy(buf);
+		rc = pldm_msgbuf_complete(buf);
 		if (rc) {
 			return pldm_xlate_errno(rc);
 		}
@@ -1288,7 +1288,7 @@ int encode_poll_for_platform_event_message_resp(
 		pldm_msgbuf_insert(buf, checksum);
 	}
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -1390,7 +1390,7 @@ int decode_platform_event_message_resp(const struct pldm_msg *msg,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -1455,7 +1455,7 @@ int decode_event_message_buffer_size_resp(const struct pldm_msg *msg,
 
 	pldm_msgbuf_extract_p(buf, terminus_max_buffer_size);
 
-	rc = pldm_msgbuf_destroy_consumed(buf);
+	rc = pldm_msgbuf_complete_consumed(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -1548,7 +1548,7 @@ int decode_event_message_supported_resp(const struct pldm_msg *msg,
 	}
 
 	if (*number_event_class_returned == 0) {
-		rc = pldm_msgbuf_destroy(buf);
+		rc = pldm_msgbuf_complete(buf);
 		if (rc) {
 			return pldm_xlate_errno(rc);
 		}
@@ -1564,7 +1564,7 @@ int decode_event_message_supported_resp(const struct pldm_msg *msg,
 		pldm_msgbuf_extract(buf, event_class[i]);
 	}
 
-	rc = pldm_msgbuf_destroy_consumed(buf);
+	rc = pldm_msgbuf_complete_consumed(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -1631,7 +1631,7 @@ int decode_sensor_event_data(const uint8_t *event_data,
 	*event_class_data_offset =
 		sizeof(*sensor_id) + sizeof(*sensor_event_class_type);
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -1662,7 +1662,7 @@ int decode_sensor_op_data(const uint8_t *sensor_data, size_t sensor_data_length,
 	pldm_msgbuf_extract_p(buf, present_op_state);
 	pldm_msgbuf_extract_p(buf, previous_op_state);
 
-	rc = pldm_msgbuf_destroy_consumed(buf);
+	rc = pldm_msgbuf_complete_consumed(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -1696,7 +1696,7 @@ int decode_state_sensor_data(const uint8_t *sensor_data,
 	pldm_msgbuf_extract_p(buf, event_state);
 	pldm_msgbuf_extract_p(buf, previous_event_state);
 
-	rc = pldm_msgbuf_destroy_consumed(buf);
+	rc = pldm_msgbuf_complete_consumed(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -1792,7 +1792,7 @@ int decode_numeric_sensor_data(const uint8_t *sensor_data,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	rc = pldm_msgbuf_destroy_consumed(buf);
+	rc = pldm_msgbuf_complete_consumed(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -1893,7 +1893,7 @@ int decode_numeric_sensor_pdr_data(
 	pldm_msgbuf_extract_range_field_format(
 		buf, pdr_value->range_field_format, pdr_value->fatal_low);
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -2031,7 +2031,7 @@ int decode_get_numeric_effecter_value_req(const struct pldm_msg *msg,
 
 	pldm_msgbuf_extract_p(buf, effecter_id);
 
-	rc = pldm_msgbuf_destroy_consumed(buf);
+	rc = pldm_msgbuf_complete_consumed(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -2097,7 +2097,7 @@ int decode_get_numeric_effecter_value_resp(const struct pldm_msg *msg,
 	pldm_msgbuf_extract_effecter_value(buf, *effecter_data_size,
 					   present_value);
 
-	rc = pldm_msgbuf_destroy_consumed(buf);
+	rc = pldm_msgbuf_complete_consumed(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -2199,7 +2199,7 @@ int decode_pldm_pdr_repository_chg_event_data(const uint8_t *event_data,
 	*change_record_data_offset =
 		sizeof(*event_data_format) + sizeof(*number_of_change_records);
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -2238,7 +2238,7 @@ int decode_pldm_message_poll_event_data(
 
 	pldm_msgbuf_extract(buf, poll_event->data_transfer_handle);
 
-	return pldm_msgbuf_destroy_consumed(buf);
+	return pldm_msgbuf_complete_consumed(buf);
 }
 
 LIBPLDM_ABI_TESTING
@@ -2267,7 +2267,7 @@ int encode_pldm_message_poll_event_data(
 	pldm_msgbuf_insert(buf, poll_event->event_id);
 	pldm_msgbuf_insert(buf, poll_event->data_transfer_handle);
 
-	return pldm_msgbuf_destroy_consumed(buf);
+	return pldm_msgbuf_complete_consumed(buf);
 }
 
 LIBPLDM_ABI_STABLE
@@ -2299,7 +2299,7 @@ int decode_pldm_pdr_repository_change_record_data(
 	*change_entry_data_offset = sizeof(*event_data_operation) +
 				    sizeof(*number_of_change_entries);
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -2389,7 +2389,7 @@ int decode_get_sensor_reading_resp(
 	pldm_msgbuf_extract_sensor_value(buf, *sensor_data_size,
 					 present_reading);
 
-	rc = pldm_msgbuf_destroy_consumed(buf);
+	rc = pldm_msgbuf_complete_consumed(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -2490,7 +2490,7 @@ int decode_get_sensor_reading_req(const struct pldm_msg *msg,
 	pldm_msgbuf_extract_p(buf, sensor_id);
 	pldm_msgbuf_extract_p(buf, rearm_event_state);
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -2564,7 +2564,7 @@ int decode_set_event_receiver_resp(const struct pldm_msg *msg,
 
 	pldm_msgbuf_extract_p(buf, completion_code);
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -2609,7 +2609,7 @@ int decode_set_event_receiver_req(const struct pldm_msg *msg,
 		pldm_msgbuf_extract_p(buf, heartbeat_timer);
 	}
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -2694,7 +2694,7 @@ int encode_poll_for_platform_event_message_req(uint8_t instance_id,
 	pldm_msgbuf_insert(buf, data_transfer_handle);
 	pldm_msgbuf_insert(buf, event_id_to_acknowledge);
 
-	rc = pldm_msgbuf_destroy(buf);
+	rc = pldm_msgbuf_complete(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -2770,7 +2770,7 @@ int decode_poll_for_platform_event_message_resp(
 		pldm_msgbuf_extract_p(buf, event_data_integrity_checksum);
 	}
 
-	rc = pldm_msgbuf_destroy_consumed(buf);
+	rc = pldm_msgbuf_complete_consumed(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -2866,7 +2866,7 @@ int decode_numeric_effecter_pdr_data(
 	pldm_msgbuf_extract_range_field_format(
 		buf, pdr_value->range_field_format, pdr_value->rated_min);
 
-	rc = pldm_msgbuf_destroy_consumed(buf);
+	rc = pldm_msgbuf_complete_consumed(buf);
 	if (rc) {
 		return pldm_xlate_errno(rc);
 	}
@@ -2908,7 +2908,7 @@ int encode_get_state_effecter_states_req(uint8_t instance_id,
 
 	pldm_msgbuf_insert(buf, effecter_id);
 
-	return pldm_msgbuf_destroy_consumed(buf);
+	return pldm_msgbuf_complete_consumed(buf);
 }
 
 LIBPLDM_ABI_STABLE
@@ -2933,7 +2933,7 @@ int decode_get_state_effecter_states_req(const struct pldm_msg *msg,
 
 	pldm_msgbuf_extract_p(buf, effecter_id);
 
-	return pldm_msgbuf_destroy_consumed(buf);
+	return pldm_msgbuf_complete_consumed(buf);
 }
 
 LIBPLDM_ABI_STABLE
@@ -2986,7 +2986,7 @@ int decode_get_state_effecter_states_resp(
 		pldm_msgbuf_extract(buf, field->present_state);
 	}
 
-	return pldm_msgbuf_destroy_consumed(buf);
+	return pldm_msgbuf_complete_consumed(buf);
 }
 
 LIBPLDM_ABI_STABLE
@@ -3039,7 +3039,7 @@ int encode_get_state_effecter_states_resp(
 		pldm_msgbuf_insert(buf, field->present_state);
 	}
 
-	return pldm_msgbuf_destroy_consumed(buf);
+	return pldm_msgbuf_complete_consumed(buf);
 }
 
 LIBPLDM_ABI_STABLE
@@ -3132,7 +3132,7 @@ int decode_entity_auxiliary_names_pdr(
 		}
 	}
 
-	rc = pldm_msgbuf_destroy_consumed(src);
+	rc = pldm_msgbuf_complete_consumed(src);
 	if (rc < 0) {
 		return rc;
 	}
@@ -3151,9 +3151,9 @@ int decode_entity_auxiliary_names_pdr(
 		pldm_msgbuf_span_string_utf16(src, NULL, NULL);
 	}
 
-	if ((rc = pldm_msgbuf_destroy(dst)) ||
-	    (rc = pldm_msgbuf_destroy(src)) ||
-	    (rc = pldm_msgbuf_destroy(buf))) {
+	if ((rc = pldm_msgbuf_complete(dst)) ||
+	    (rc = pldm_msgbuf_complete(src)) ||
+	    (rc = pldm_msgbuf_complete(buf))) {
 		return rc;
 	}
 
@@ -3218,7 +3218,7 @@ int decode_pldm_entity_auxiliary_names_pdr_index(
 		pdr->names[i].tag = loc;
 	}
 
-	return pldm_msgbuf_destroy_consumed(buf);
+	return pldm_msgbuf_complete_consumed(buf);
 }
 
 LIBPLDM_ABI_STABLE
@@ -3273,7 +3273,7 @@ int decode_pldm_platform_cper_event(const void *event_data,
 		return rc;
 	}
 
-	return pldm_msgbuf_destroy_consumed(buf);
+	return pldm_msgbuf_complete_consumed(buf);
 }
 
 LIBPLDM_ABI_STABLE

--- a/src/firmware_device/fd.c
+++ b/src/firmware_device/fd.c
@@ -363,8 +363,8 @@ static int pldm_fd_fw_param(struct pldm_fd *fd,
 		}
 	}
 
-	return pldm_msgbuf_destroy_used(buf, *resp_payload_len,
-					resp_payload_len);
+	return pldm_msgbuf_complete_used(buf, *resp_payload_len,
+					 resp_payload_len);
 }
 
 LIBPLDM_CC_NONNULL

--- a/src/msgbuf.h
+++ b/src/msgbuf.h
@@ -144,15 +144,21 @@ int pldm_msgbuf_validate(struct pldm_msgbuf *ctx)
  * @param[in] ctx - pldm_msgbuf context for extractor
  *
  * @return 0 iff there are zero bytes of data that remain unread from the buffer
- * and no overflow has occurred. Otherwise, -EBADMSG.
+ * and no overflow has occurred. Otherwise, -EBADMSG if the buffer has not been
+ * completely consumed, or -EOVERFLOW if accesses were attempted beyond the
+ * bounds of the buffer.
  */
 LIBPLDM_CC_NONNULL
 LIBPLDM_CC_ALWAYS_INLINE
 LIBPLDM_CC_WARN_UNUSED_RESULT
 int pldm_msgbuf_consumed(struct pldm_msgbuf *ctx)
 {
-	if (ctx->remaining != 0) {
+	if (ctx->remaining > 0) {
 		return -EBADMSG;
+	}
+
+	if (ctx->remaining < 0) {
+		return -EOVERFLOW;
 	}
 
 	return 0;
@@ -187,7 +193,9 @@ int pldm_msgbuf_complete(struct pldm_msgbuf *ctx)
  * @param[in] ctx - pldm_msgbuf context
  *
  * @return 0 if all buffer access were in-bounds and completely consume the
- * underlying buffer. Otherwise, -EBADMSG.
+ * underlying buffer. Otherwise, -EBADMSG if the buffer has not been completely
+ * consumed, or -EOVERFLOW if accesses were attempted beyond the bounds of the
+ * buffer.
  */
 LIBPLDM_CC_NONNULL
 LIBPLDM_CC_ALWAYS_INLINE

--- a/src/msgbuf.h
+++ b/src/msgbuf.h
@@ -1171,16 +1171,17 @@ LIBPLDM_CC_ALWAYS_INLINE int pldm_msgbuf_skip(struct pldm_msgbuf *ctx,
 	}
 #endif
 
-	if (ctx->remaining < INTMAX_MIN + (intmax_t)count) {
-		return -EOVERFLOW;
+	if (ctx->remaining >= (intmax_t)count) {
+		ctx->cursor += count;
+		ctx->remaining -= (intmax_t)count;
+		return 0;
 	}
-	ctx->remaining -= (intmax_t)count;
-	if (ctx->remaining < 0) {
-		return -EOVERFLOW;
-	}
-	ctx->cursor += count;
 
-	return 0;
+	if (ctx->remaining >= INTMAX_MIN + (intmax_t)count) {
+		ctx->remaining -= (intmax_t)count;
+	}
+
+	return -EOVERFLOW;
 }
 
 /**

--- a/src/msgbuf.h
+++ b/src/msgbuf.h
@@ -962,7 +962,7 @@ LIBPLDM_CC_ALWAYS_INLINE int pldm_msgbuf_span_required(struct pldm_msgbuf *ctx,
 						       size_t required,
 						       void **cursor)
 {
-	if (!ctx->cursor || (cursor && *cursor)) {
+	if (!ctx->cursor) {
 		return -EINVAL;
 	}
 
@@ -995,7 +995,7 @@ pldm_msgbuf_span_string_ascii(struct pldm_msgbuf *ctx, void **cursor,
 {
 	intmax_t measured;
 
-	if (!ctx->cursor || (cursor && *cursor)) {
+	if (!ctx->cursor) {
 		return -EINVAL;
 	}
 
@@ -1050,7 +1050,7 @@ pldm_msgbuf_span_string_utf16(struct pldm_msgbuf *ctx, void **cursor,
 	ptrdiff_t measured;
 	void *end;
 
-	if (!ctx->cursor || (cursor && *cursor)) {
+	if (!ctx->cursor) {
 		return -EINVAL;
 	}
 
@@ -1123,7 +1123,7 @@ LIBPLDM_CC_NONNULL
 LIBPLDM_CC_ALWAYS_INLINE int
 pldm_msgbuf_span_remaining(struct pldm_msgbuf *ctx, void **cursor, size_t *len)
 {
-	if (!ctx->cursor || *cursor) {
+	if (!ctx->cursor) {
 		return -EINVAL;
 	}
 
@@ -1143,7 +1143,7 @@ LIBPLDM_CC_NONNULL
 LIBPLDM_CC_ALWAYS_INLINE int
 pldm_msgbuf_peek_remaining(struct pldm_msgbuf *ctx, void **cursor, size_t *len)
 {
-	if (!ctx->cursor || *cursor) {
+	if (!ctx->cursor) {
 		return -EINVAL;
 	}
 

--- a/src/msgbuf.h
+++ b/src/msgbuf.h
@@ -88,7 +88,9 @@ struct pldm_msgbuf {
  *         personality.
  */
 LIBPLDM_CC_NONNULL
-LIBPLDM_CC_ALWAYS_INLINE int
+LIBPLDM_CC_ALWAYS_INLINE
+LIBPLDM_CC_WARN_UNUSED_RESULT
+int
 // NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
 pldm_msgbuf_init_errno(struct pldm_msgbuf *ctx, size_t minsize, const void *buf,
 		       size_t len)
@@ -125,7 +127,9 @@ pldm_msgbuf_init_errno(struct pldm_msgbuf *ctx, size_t minsize, const void *buf,
  * pointer.
  */
 LIBPLDM_CC_NONNULL
-LIBPLDM_CC_ALWAYS_INLINE int pldm_msgbuf_validate(struct pldm_msgbuf *ctx)
+LIBPLDM_CC_ALWAYS_INLINE
+LIBPLDM_CC_WARN_UNUSED_RESULT
+int pldm_msgbuf_validate(struct pldm_msgbuf *ctx)
 {
 	if (ctx->remaining < 0) {
 		return -EOVERFLOW;
@@ -146,7 +150,9 @@ LIBPLDM_CC_ALWAYS_INLINE int pldm_msgbuf_validate(struct pldm_msgbuf *ctx)
  * pointer.
  */
 LIBPLDM_CC_NONNULL
-LIBPLDM_CC_ALWAYS_INLINE int pldm_msgbuf_consumed(struct pldm_msgbuf *ctx)
+LIBPLDM_CC_ALWAYS_INLINE
+LIBPLDM_CC_WARN_UNUSED_RESULT
+int pldm_msgbuf_consumed(struct pldm_msgbuf *ctx)
 {
 	if (ctx->remaining != 0) {
 		return -EBADMSG;
@@ -166,7 +172,9 @@ LIBPLDM_CC_ALWAYS_INLINE int pldm_msgbuf_consumed(struct pldm_msgbuf *ctx)
  * bounds of the buffer.
  */
 LIBPLDM_CC_NONNULL
-LIBPLDM_CC_ALWAYS_INLINE int pldm_msgbuf_destroy(struct pldm_msgbuf *ctx)
+LIBPLDM_CC_ALWAYS_INLINE
+LIBPLDM_CC_WARN_UNUSED_RESULT
+int pldm_msgbuf_destroy(struct pldm_msgbuf *ctx)
 {
 	int valid;
 
@@ -190,8 +198,9 @@ LIBPLDM_CC_ALWAYS_INLINE int pldm_msgbuf_destroy(struct pldm_msgbuf *ctx)
  * have occurred byond the bounds of the buffer
  */
 LIBPLDM_CC_NONNULL
-LIBPLDM_CC_ALWAYS_INLINE int
-pldm_msgbuf_destroy_consumed(struct pldm_msgbuf *ctx)
+LIBPLDM_CC_ALWAYS_INLINE
+LIBPLDM_CC_WARN_UNUSED_RESULT
+int pldm_msgbuf_destroy_consumed(struct pldm_msgbuf *ctx)
 {
 	int consumed;
 
@@ -1187,11 +1196,13 @@ LIBPLDM_CC_ALWAYS_INLINE int pldm_msgbuf_skip(struct pldm_msgbuf *ctx,
  *
  */
 LIBPLDM_CC_NONNULL
-LIBPLDM_CC_ALWAYS_INLINE int pldm_msgbuf_destroy_used(struct pldm_msgbuf *ctx,
-						      size_t orig_len,
-						      size_t *ret_used_len)
+LIBPLDM_CC_ALWAYS_INLINE
+LIBPLDM_CC_WARN_UNUSED_RESULT
+int pldm_msgbuf_destroy_used(struct pldm_msgbuf *ctx, size_t orig_len,
+			     size_t *ret_used_len)
 {
 	int rc;
+
 	rc = pldm_msgbuf_validate(ctx);
 	if (rc) {
 		return rc;

--- a/src/oem/meta/file_io.c
+++ b/src/oem/meta/file_io.c
@@ -52,7 +52,7 @@ int decode_oem_meta_file_io_write_req(
 		return rc;
 	}
 
-	return pldm_msgbuf_destroy_consumed(buf);
+	return pldm_msgbuf_complete_consumed(buf);
 }
 
 LIBPLDM_ABI_DEPRECATED_UNSAFE
@@ -142,7 +142,7 @@ int decode_oem_meta_file_io_read_req(const struct pldm_msg *msg,
 		return -EPROTO;
 	}
 
-	return pldm_msgbuf_destroy_consumed(buf);
+	return pldm_msgbuf_complete_consumed(buf);
 }
 
 LIBPLDM_ABI_STABLE
@@ -214,5 +214,5 @@ int encode_oem_meta_file_io_read_resp(
 		return -EPROTO;
 	}
 
-	return pldm_msgbuf_destroy(buf);
+	return pldm_msgbuf_complete(buf);
 }

--- a/src/requester/instance-id.c
+++ b/src/requester/instance-id.c
@@ -219,6 +219,11 @@ int pldm_instance_id_free(struct pldm_instance_db *ctx, pldm_tid_t tid,
 	struct flock flop;
 	int rc;
 
+	/* check if provided context is null */
+	if (!ctx) {
+		return -EINVAL;
+	}
+
 	/* Trying to free an instance ID that is not currently allocated */
 	if (!(ctx->state[tid].allocations & BIT(iid))) {
 		return -EINVAL;

--- a/src/requester/instance-id.c
+++ b/src/requester/instance-id.c
@@ -122,7 +122,7 @@ int pldm_instance_id_alloc(struct pldm_instance_db *ctx, pldm_tid_t tid,
 {
 	uint8_t l_iid;
 
-	if (!iid) {
+	if (!ctx || !iid) {
 		return -EINVAL;
 	}
 

--- a/tests/dsp/firmware_update.cpp
+++ b/tests/dsp/firmware_update.cpp
@@ -1657,7 +1657,7 @@ TEST(QueryDownstreamIdentifiers, decodeResponseNoDevices)
     pldm_msgbuf_insert_uint32(buf, downstream_devices_length_resp);
     pldm_msgbuf_insert_uint16(buf, number_of_downstream_devices_resp);
 
-    ASSERT_EQ(pldm_msgbuf_destroy_consumed(buf), 0);
+    ASSERT_EQ(pldm_msgbuf_complete_consumed(buf), 0);
 
     rc = decode_query_downstream_identifiers_resp(
         response, PLDM_QUERY_DOWNSTREAM_IDENTIFIERS_RESP_MIN_LEN, &resp_data,
@@ -1700,7 +1700,7 @@ TEST(QueryDownstreamIdentifiers, decodeResponseNoDevicesBadCount)
     pldm_msgbuf_insert_uint32(buf, downstream_devices_length_resp);
     pldm_msgbuf_insert_uint16(buf, number_of_downstream_devices_resp);
 
-    ASSERT_EQ(pldm_msgbuf_destroy_consumed(buf), 0);
+    ASSERT_EQ(pldm_msgbuf_complete_consumed(buf), 0);
 
     rc = decode_query_downstream_identifiers_resp(
         response, PLDM_QUERY_DOWNSTREAM_IDENTIFIERS_RESP_MIN_LEN, &resp, &devs);
@@ -1751,7 +1751,7 @@ TEST(QueryDownstreamIdentifiers, decodeResponseOneDeviceOneDescriptor)
     pldm_msgbuf_insert_uint16(buf, 4);
     pldm_msgbuf_insert_uint32(buf, 412);
 
-    ASSERT_EQ(pldm_msgbuf_destroy_consumed(buf), 0);
+    ASSERT_EQ(pldm_msgbuf_complete_consumed(buf), 0);
 
     rc = decode_query_downstream_identifiers_resp(response, payloadLen,
                                                   &resp_data, &devs);
@@ -1849,7 +1849,7 @@ TEST(QueryDownstreamIdentifiers, decodeResponseTwoDevicesOneDescriptorEach)
     pldm_msgbuf_insert_uint16(buf, descriptor_id_len_iana_pen);
     pldm_msgbuf_insert_uint32(buf, iana_pen_openbmc);
 
-    ASSERT_EQ(pldm_msgbuf_destroy_consumed(buf), 0);
+    ASSERT_EQ(pldm_msgbuf_complete_consumed(buf), 0);
 
     rc = decode_query_downstream_identifiers_resp(response, payloadLen,
                                                   &resp_data, &devs);
@@ -1965,7 +1965,7 @@ TEST(QueryDownstreamIdentifiers, decodeResponseTwoDevicesTwoOneDescriptors)
     pldm_msgbuf_insert_uint16(buf, descriptor_id_len_iana_pen);
     pldm_msgbuf_insert_uint32(buf, iana_pen_dmtf);
 
-    ASSERT_EQ(pldm_msgbuf_destroy_consumed(buf), 0);
+    ASSERT_EQ(pldm_msgbuf_complete_consumed(buf), 0);
 
     rc = decode_query_downstream_identifiers_resp(response, payloadLen,
                                                   &resp_data, &devs);
@@ -2081,7 +2081,7 @@ TEST(QueryDownstreamIdentifiers, decodeResponseTwoDevicesOneTwoDescriptors)
     pldm_msgbuf_insert_uint16(buf, descriptor_id_len_iana_pen);
     pldm_msgbuf_insert_uint32(buf, iana_pen_dmtf);
 
-    ASSERT_EQ(pldm_msgbuf_destroy_consumed(buf), 0);
+    ASSERT_EQ(pldm_msgbuf_complete_consumed(buf), 0);
 
     rc = decode_query_downstream_identifiers_resp(response, payloadLen,
                                                   &resp_data, &devs);
@@ -2361,7 +2361,7 @@ TEST(GetDownstreamFirmwareParameters, goodPathDecodeResponseOneEntry)
         buf, pendingComponentVersionStringLength, "zyxwvuts", 8);
     ASSERT_EQ(rc, 0);
 
-    rc = pldm_msgbuf_destroy_consumed(buf);
+    rc = pldm_msgbuf_complete_consumed(buf);
     ASSERT_EQ(rc, 0);
 
     struct pldm_get_downstream_firmware_parameters_resp resp_data = {};
@@ -2510,7 +2510,7 @@ TEST(GetDownstreamFirmwareParameters, goodPathDecodeResponseTwoEntries)
         ASSERT_EQ(rc, 0);
     }
 
-    rc = pldm_msgbuf_destroy_consumed(buf);
+    rc = pldm_msgbuf_complete_consumed(buf);
     ASSERT_EQ(rc, 0);
 
     struct pldm_get_downstream_firmware_parameters_resp resp_data = {};

--- a/tests/dsp/firmware_update.cpp
+++ b/tests/dsp/firmware_update.cpp
@@ -2284,7 +2284,7 @@ TEST(GetDownstreamFirmwareParameters, encodeRequestErrorBufSize)
     constexpr uint8_t instanceId = 1;
     // Setup invalid transfer operation flag
     constexpr pldm_get_downstream_firmware_parameters_req params_req{
-        0x0, PLDM_ACKNOWLEDGEMENT_ONLY};
+        0x0, PLDM_GET_FIRSTPART};
     constexpr size_t payload_length =
         PLDM_GET_DOWNSTREAM_FIRMWARE_PARAMETERS_REQ_BYTES -
         1 /* inject erro length*/;

--- a/tests/dsp/pdr.cpp
+++ b/tests/dsp/pdr.cpp
@@ -11,6 +11,83 @@
 
 #include <gtest/gtest.h>
 
+typedef struct pldm_association_pdr_test
+{
+    uint32_t record_handle;
+    uint8_t version;
+    uint8_t type;
+    uint16_t record_change_num;
+    uint16_t length;
+    uint16_t container_id;
+    uint8_t association_type;
+    uint8_t num_children;
+
+    inline bool operator==(pldm_association_pdr_test pdr) const
+    {
+        return (record_handle == pdr.record_handle) && (type == pdr.type) &&
+               (length == pdr.length) && (container_id == pdr.container_id) &&
+               (association_type == pdr.association_type) &&
+               (num_children == pdr.num_children);
+    }
+} pldm_association_pdr_test;
+
+typedef struct pldm_entity_test
+{
+    uint16_t entity_type;
+    uint16_t entity_instance_num;
+    uint16_t entity_container_id;
+
+    inline bool operator==(pldm_entity_test entity) const
+    {
+        return (entity_type == entity.entity_type) &&
+               (entity_instance_num == entity.entity_instance_num) &&
+               (entity_container_id == entity.entity_container_id);
+    }
+} pldm_entity_test;
+
+static void getEntity(struct pldm_msgbuf* buf, pldm_entity_test& entity)
+{
+    pldm_msgbuf_extract_uint16(buf, entity.entity_type);
+    pldm_msgbuf_extract_uint16(buf, entity.entity_instance_num);
+    pldm_msgbuf_extract_uint16(buf, entity.entity_container_id);
+}
+
+static void
+    getAssociationPdrDetails(struct pldm_msgbuf* buf,
+                             pldm_association_pdr_test& association_pdr_test)
+{
+    pldm_msgbuf_extract_uint32(buf, association_pdr_test.record_handle);
+    pldm_msgbuf_extract_uint8(buf, association_pdr_test.version);
+    pldm_msgbuf_extract_uint8(buf, association_pdr_test.type);
+    pldm_msgbuf_extract_uint16(buf, association_pdr_test.record_change_num);
+    pldm_msgbuf_extract_uint16(buf, association_pdr_test.length);
+
+    pldm_msgbuf_extract_uint16(buf, association_pdr_test.container_id);
+    pldm_msgbuf_extract_uint8(buf, association_pdr_test.association_type);
+}
+
+static void
+    verifyEntityAssociationPdr(struct pldm_msgbuf* buf,
+                               const pldm_association_pdr_test& association_pdr,
+                               const pldm_entity_test& container_entity1,
+                               const pldm_entity_test& child_entity1)
+{
+    struct pldm_entity_test container_entity = {};
+    struct pldm_entity_test child_entity = {};
+    pldm_association_pdr_test association_pdr_test{};
+
+    getAssociationPdrDetails(buf, association_pdr_test);
+    getEntity(buf, container_entity);
+    pldm_msgbuf_extract_uint8(buf, association_pdr_test.num_children);
+    getEntity(buf, child_entity);
+
+    ASSERT_EQ(pldm_msgbuf_destroy_consumed(buf), 0);
+
+    EXPECT_TRUE(association_pdr_test == association_pdr);
+    EXPECT_TRUE(container_entity == container_entity1);
+    EXPECT_TRUE(child_entity == child_entity1);
+}
+
 TEST(PDRAccess, testInit)
 {
     auto repo = pldm_pdr_init();
@@ -1426,6 +1503,103 @@ TEST(EntityAssociationPDR, testPDR)
     pldm_entity_association_tree_destroy(tree);
 }
 
+TEST(EntityAssociationPDR, testPDRWithRecordHandle)
+{
+    // e = entity type, c = container id, i = instance num
+
+    //        INPUT
+    //        1(e=1)
+    //        |
+    //        2(e=2)--3(e=2)
+
+    //        Expected OUTPUT
+    //        1(e=1,c=0,i=1)
+    //        |
+    //        2(e=2,c=1,i=1)--3(e=2,c=1,i=2)
+
+    pldm_entity entities[3] = {{1, 1, 0}, {2, 1, 1}, {3, 1, 1}};
+    pldm_entity_test testEntities[3] = {{1, 1, 0}, {2, 1, 1}, {3, 1, 1}};
+
+    auto tree = pldm_entity_association_tree_init();
+
+    auto l1 = pldm_entity_association_tree_add(
+        tree, &entities[0], 0xffff, nullptr, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    ASSERT_NE(l1, nullptr);
+
+    auto l2a = pldm_entity_association_tree_add(
+        tree, &entities[1], 0xffff, l1, PLDM_ENTITY_ASSOCIAION_PHYSICAL);
+    ASSERT_NE(l2a, nullptr);
+    pldm_entity_association_tree_add(tree, &entities[2], 0xffff, l1,
+                                     PLDM_ENTITY_ASSOCIAION_LOGICAL);
+    auto repo = pldm_pdr_init();
+    pldm_entity* l_entities = entities;
+
+    pldm_entity_node* node = nullptr;
+    pldm_find_entity_ref_in_tree(tree, entities[0], &node);
+
+    ASSERT_NE(node, nullptr);
+
+    int numEntities = 3;
+    pldm_entity_association_pdr_add_from_node_with_record_handle(
+        node, repo, &l_entities, numEntities, true, 1, (10));
+
+    EXPECT_EQ(pldm_pdr_get_record_count(repo), 2u);
+
+    uint32_t currRecHandle{};
+    uint32_t nextRecHandle{};
+    uint8_t* data = nullptr;
+    uint32_t size{};
+
+    pldm_pdr_find_record(repo, currRecHandle, &data, &size, &nextRecHandle);
+
+    struct pldm_msgbuf _buf;
+    struct pldm_msgbuf* buf = &_buf;
+
+    auto rc =
+        pldm_msgbuf_init_errno(buf,
+                               (sizeof(struct pldm_pdr_hdr) +
+                                sizeof(struct pldm_pdr_entity_association)),
+                               data, size);
+    ASSERT_EQ(rc, 0);
+
+    pldm_association_pdr_test association_pdr = pldm_association_pdr_test{
+        10,
+        1,
+        PLDM_PDR_ENTITY_ASSOCIATION,
+        1,
+        static_cast<uint16_t>(size - sizeof(struct pldm_pdr_hdr)),
+        1,
+        PLDM_ENTITY_ASSOCIAION_LOGICAL,
+        1};
+
+    verifyEntityAssociationPdr(buf, association_pdr, testEntities[0],
+                               testEntities[2]);
+
+    currRecHandle = nextRecHandle;
+    pldm_pdr_find_record(repo, currRecHandle, &data, &size, &nextRecHandle);
+    rc = pldm_msgbuf_init_errno(buf,
+                                (sizeof(struct pldm_pdr_hdr) +
+                                 sizeof(struct pldm_pdr_entity_association)),
+                                data, size);
+    ASSERT_EQ(rc, 0);
+
+    pldm_association_pdr_test association_pdr1 = pldm_association_pdr_test{
+        11,
+        1,
+        PLDM_PDR_ENTITY_ASSOCIATION,
+        1,
+        static_cast<uint16_t>(size - sizeof(struct pldm_pdr_hdr)),
+        1,
+        PLDM_ENTITY_ASSOCIAION_PHYSICAL,
+        1};
+
+    verifyEntityAssociationPdr(buf, association_pdr1, testEntities[0],
+                               testEntities[1]);
+
+    pldm_pdr_destroy(repo);
+    pldm_entity_association_tree_destroy(tree);
+}
+
 TEST(EntityAssociationPDR, testFind)
 {
     //        1
@@ -1562,12 +1736,12 @@ TEST(EntityAssociationPDR, testExtract)
 {
     std::vector<uint8_t> pdr{};
     pdr.resize(sizeof(pldm_pdr_hdr) + sizeof(pldm_pdr_entity_association) +
-               sizeof(pldm_entity) * 5);
+               sizeof(pldm_entity) * 4);
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     pldm_pdr_hdr* hdr = reinterpret_cast<pldm_pdr_hdr*>(pdr.data());
     hdr->type = PLDM_PDR_ENTITY_ASSOCIATION;
     hdr->length =
-        htole16(sizeof(pldm_pdr_entity_association) + sizeof(pldm_entity) * 5);
+        htole16(sizeof(pldm_pdr_entity_association) + sizeof(pldm_entity) * 4);
 
     pldm_pdr_entity_association* e =
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)

--- a/tests/dsp/pdr.cpp
+++ b/tests/dsp/pdr.cpp
@@ -81,7 +81,7 @@ static void
     pldm_msgbuf_extract_uint8(buf, association_pdr_test.num_children);
     getEntity(buf, child_entity);
 
-    ASSERT_EQ(pldm_msgbuf_destroy_consumed(buf), 0);
+    ASSERT_EQ(pldm_msgbuf_complete_consumed(buf), 0);
 
     EXPECT_TRUE(association_pdr_test == association_pdr);
     EXPECT_TRUE(container_entity == container_entity1);

--- a/tests/dsp/pdr.cpp
+++ b/tests/dsp/pdr.cpp
@@ -772,6 +772,38 @@ TEST(PDRAccess, testGetTerminusHandle)
 }
 #endif
 
+#ifdef LIBPLDM_API_TESTING
+TEST(PDRAccess, testRemoveByRecordHandle)
+{
+    std::array<uint8_t, sizeof(pldm_pdr_hdr)> data{};
+
+    auto repo = pldm_pdr_init();
+    uint32_t first = 0;
+    EXPECT_EQ(pldm_pdr_add(repo, data.data(), data.size(), false, 1, &first),
+              0);
+
+    uint32_t second = 0;
+    EXPECT_EQ(pldm_pdr_add(repo, data.data(), data.size(), false, 1, &second),
+              0);
+
+    uint32_t third = 0;
+    EXPECT_EQ(pldm_pdr_add(repo, data.data(), data.size(), false, 1, &third),
+              0);
+
+    EXPECT_EQ(pldm_pdr_get_record_count(repo), 3u);
+
+    int rc = pldm_pdr_delete_by_record_handle(repo, 1, false);
+    EXPECT_EQ(rc, 0);
+    EXPECT_EQ(pldm_pdr_get_record_count(repo), 2u);
+
+    rc = pldm_pdr_delete_by_record_handle(repo, 2, false);
+    EXPECT_EQ(rc, 0);
+    EXPECT_EQ(pldm_pdr_get_record_count(repo), 1u);
+
+    pldm_pdr_destroy(repo);
+}
+#endif
+
 TEST(EntityAssociationPDR, testInit)
 {
     auto tree = pldm_entity_association_tree_init();

--- a/tests/dsp/platform.cpp
+++ b/tests/dsp/platform.cpp
@@ -486,7 +486,7 @@ TEST(GetPDR, testGoodDecodeResponseSafe)
                                        sizeof(recordData) - 1);
     ASSERT_EQ(rc, 0);
     pldm_msgbuf_insert_uint8(buf, 96);
-    ASSERT_EQ(pldm_msgbuf_destroy_consumed(buf), 0);
+    ASSERT_EQ(pldm_msgbuf_complete_consumed(buf), 0);
 
     alignas(pldm_get_pdr_resp) unsigned char
         resp_data[sizeof(pldm_get_pdr_resp) + sizeof(recordData) - 1];
@@ -730,7 +730,7 @@ TEST(GetPDRRepositoryInfo, testGoodDecodeResponseSafe)
     pldm_msgbuf_insert_uint32(buf, 100);
     pldm_msgbuf_insert_uint32(buf, UINT32_MAX);
     pldm_msgbuf_insert_uint8(buf, PLDM_NO_TIMEOUT);
-    ASSERT_EQ(pldm_msgbuf_destroy_consumed(buf), 0);
+    ASSERT_EQ(pldm_msgbuf_complete_consumed(buf), 0);
 
     struct pldm_pdr_repository_info_resp resp;
     rc = decode_get_pdr_repository_info_resp_safe(
@@ -1482,7 +1482,7 @@ TEST(PollForPlatformEventMessage, testGoodEncodeRequestFirstPart)
     pldm_msgbuf_extract_uint8(buf, retTransferOperationFlag);
     pldm_msgbuf_extract_uint32(buf, retDataTransferHandle);
     pldm_msgbuf_extract_uint16(buf, retEventIdToAcknowledge);
-    ASSERT_EQ(pldm_msgbuf_destroy_consumed(buf), 0);
+    ASSERT_EQ(pldm_msgbuf_complete_consumed(buf), 0);
 
     EXPECT_EQ(retFormatVersion, formatVersion);
     EXPECT_EQ(retTransferOperationFlag, transferOperationFlag);
@@ -1521,7 +1521,7 @@ TEST(PollForPlatformEventMessage, testGoodEncodeRequestNextPart)
     pldm_msgbuf_extract_uint8(buf, retTransferOperationFlag);
     pldm_msgbuf_extract_uint32(buf, retDataTransferHandle);
     pldm_msgbuf_extract_uint16(buf, retEventIdToAcknowledge);
-    ASSERT_EQ(pldm_msgbuf_destroy_consumed(buf), 0);
+    ASSERT_EQ(pldm_msgbuf_complete_consumed(buf), 0);
 
     EXPECT_EQ(retFormatVersion, formatVersion);
     EXPECT_EQ(retTransferOperationFlag, transferOperationFlag);
@@ -1560,7 +1560,7 @@ TEST(PollForPlatformEventMessage, testGoodEncodeRequestAckOnly)
     pldm_msgbuf_extract_uint8(buf, retTransferOperationFlag);
     pldm_msgbuf_extract_uint32(buf, retDataTransferHandle);
     pldm_msgbuf_extract_uint16(buf, retEventIdToAcknowledge);
-    ASSERT_EQ(pldm_msgbuf_destroy_consumed(buf), 0);
+    ASSERT_EQ(pldm_msgbuf_complete_consumed(buf), 0);
 
     EXPECT_EQ(retFormatVersion, formatVersion);
     EXPECT_EQ(retTransferOperationFlag, transferOperationFlag);
@@ -2057,7 +2057,7 @@ TEST(PollForPlatformEventMessage, testGoodEncodeResposeP1)
     EXPECT_EQ(retEventDataIntegrityChecksum, eventDataIntegrityChecksum);
     EXPECT_EQ(0, memcmp(pEventData, retEventData, eventDataSize));
 
-    EXPECT_EQ(pldm_msgbuf_destroy(buf), PLDM_SUCCESS);
+    EXPECT_EQ(pldm_msgbuf_complete(buf), PLDM_SUCCESS);
 }
 
 TEST(PollForPlatformEventMessage, testGoodEncodeResposeP2)
@@ -2097,7 +2097,7 @@ TEST(PollForPlatformEventMessage, testGoodEncodeResposeP2)
     EXPECT_EQ(retCompletionCode, completionCode);
     EXPECT_EQ(retTid, tId);
     EXPECT_EQ(retEventId, eventId);
-    EXPECT_EQ(pldm_msgbuf_destroy(buf), PLDM_SUCCESS);
+    EXPECT_EQ(pldm_msgbuf_complete(buf), PLDM_SUCCESS);
 }
 
 TEST(PollForPlatformEventMessage, testGoodEncodeResposeP3)
@@ -2137,7 +2137,7 @@ TEST(PollForPlatformEventMessage, testGoodEncodeResposeP3)
     EXPECT_EQ(retCompletionCode, completionCode);
     EXPECT_EQ(retTid, tId);
     EXPECT_EQ(retEventId, eventId);
-    EXPECT_EQ(pldm_msgbuf_destroy(buf), PLDM_SUCCESS);
+    EXPECT_EQ(pldm_msgbuf_complete(buf), PLDM_SUCCESS);
 }
 
 TEST(PollForPlatformEventMessage, testGoodEncodeResposeP4)
@@ -2202,7 +2202,7 @@ TEST(PollForPlatformEventMessage, testGoodEncodeResposeP4)
     EXPECT_EQ(retEventDataSize, eventDataSize);
     EXPECT_EQ(retEventDataIntegrityChecksum, eventDataIntegrityChecksum);
 
-    EXPECT_EQ(pldm_msgbuf_destroy(buf), PLDM_SUCCESS);
+    EXPECT_EQ(pldm_msgbuf_complete(buf), PLDM_SUCCESS);
 }
 
 TEST(PollForPlatformEventMessage, testBadEncodeResponse)
@@ -2360,7 +2360,7 @@ TEST(PlatformEventMessage, testGoodEncodeRequest)
     pldm_msgbuf_extract_uint8(buf, req.event_class);
     data = nullptr;
     pldm_msgbuf_span_remaining(buf, &data, &len);
-    ASSERT_EQ(pldm_msgbuf_destroy_consumed(buf), 0);
+    ASSERT_EQ(pldm_msgbuf_complete_consumed(buf), 0);
 
     EXPECT_EQ(formatVersion, req.format_version);
     EXPECT_EQ(Tid, req.tid);
@@ -2385,7 +2385,7 @@ TEST(PlatformEventMessage, testGoodEncodeRequest)
 
     data = nullptr;
     pldm_msgbuf_span_remaining(buf, &data, &len);
-    ASSERT_EQ(pldm_msgbuf_destroy_consumed(buf), 0);
+    ASSERT_EQ(pldm_msgbuf_complete_consumed(buf), 0);
 
     EXPECT_EQ(formatVersion, req.format_version);
     EXPECT_EQ(Tid, req.tid);
@@ -2684,7 +2684,7 @@ TEST(PlatformEventMessage, testGoodPldmMsgPollEventDataEncode)
     EXPECT_EQ(retFormatVersion, poll_event.format_version);
     EXPECT_EQ(reteventID, poll_event.event_id);
     EXPECT_EQ(retDataTransferHandle, poll_event.data_transfer_handle);
-    EXPECT_EQ(pldm_msgbuf_destroy_consumed(buf), PLDM_SUCCESS);
+    EXPECT_EQ(pldm_msgbuf_complete_consumed(buf), PLDM_SUCCESS);
 }
 #endif
 

--- a/tests/instance-id.cpp
+++ b/tests/instance-id.cpp
@@ -94,6 +94,15 @@ TEST_F(PldmInstanceDbTest, allocOnNulldb)
     EXPECT_EQ(pldm_instance_id_alloc(db, tid, &iid), -EINVAL);
 }
 
+TEST_F(PldmInstanceDbTest, freeOnNulldb)
+{
+    struct pldm_instance_db* db = nullptr;
+    const pldm_tid_t tid = 1;
+    pldm_instance_id_t iid = 1;
+
+    EXPECT_EQ(pldm_instance_id_free(db, tid, iid), -EINVAL);
+}
+
 TEST_F(PldmInstanceDbTest, allocFreeOne)
 {
     struct pldm_instance_db* db = nullptr;

--- a/tests/instance-id.cpp
+++ b/tests/instance-id.cpp
@@ -86,6 +86,14 @@ TEST_F(PldmInstanceDbTest, dbInstance)
     EXPECT_EQ(pldm_instance_db_destroy(db), 0);
 }
 
+TEST_F(PldmInstanceDbTest, allocOnNulldb)
+{
+    struct pldm_instance_db* db = nullptr;
+    const pldm_tid_t tid = 1;
+    pldm_instance_id_t iid;
+    EXPECT_EQ(pldm_instance_id_alloc(db, tid, &iid), -EINVAL);
+}
+
 TEST_F(PldmInstanceDbTest, allocFreeOne)
 {
     struct pldm_instance_db* db = nullptr;

--- a/tests/msgbuf.cpp
+++ b/tests/msgbuf.cpp
@@ -516,7 +516,7 @@ TEST(msgbuf, consumed_over)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_extract_uint8(ctx, valid), 0);
     EXPECT_NE(pldm_msgbuf_extract_uint8(ctx, invalid), 0);
-    EXPECT_EQ(pldm_msgbuf_complete_consumed(ctx), -EBADMSG);
+    EXPECT_EQ(pldm_msgbuf_complete_consumed(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, pldm_msgbuf_insert_int32_good)

--- a/tests/msgbuf.cpp
+++ b/tests/msgbuf.cpp
@@ -57,7 +57,7 @@ TEST(msgbuf, destroy_none)
     uint8_t buf[1] = {};
 
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, sizeof(buf), buf, sizeof(buf)), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, destroy_exact)
@@ -70,7 +70,7 @@ TEST(msgbuf, destroy_exact)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, sizeof(buf), buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_extract_uint8(ctx, val), 0);
     EXPECT_EQ(val, 0xa5);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, destroy_over)
@@ -84,7 +84,7 @@ TEST(msgbuf, destroy_over)
     ASSERT_EQ(pldm_msgbuf_extract_uint8(ctx, val), 0);
     ASSERT_EQ(val, 0xa5);
     EXPECT_NE(pldm_msgbuf_extract_uint8(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, destroy_under)
@@ -97,7 +97,7 @@ TEST(msgbuf, destroy_under)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, sizeof(buf), buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_extract_uint8(ctx, val), 0);
     EXPECT_EQ(val, 0x5a);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, extract_one_uint8)
@@ -110,7 +110,7 @@ TEST(msgbuf, extract_one_uint8)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, sizeof(buf), buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_extract_uint8(ctx, val), 0);
     EXPECT_EQ(val, 0xa5);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, extract_over_uint8)
@@ -122,7 +122,7 @@ TEST(msgbuf, extract_over_uint8)
 
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     EXPECT_NE(pldm_msgbuf_extract_uint8(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, extract_under_uint8)
@@ -136,7 +136,7 @@ TEST(msgbuf, extract_under_uint8)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     ctx->remaining = INTMAX_MIN;
     EXPECT_NE(pldm_msgbuf_extract_uint8(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, extract_one_int8)
@@ -149,7 +149,7 @@ TEST(msgbuf, extract_one_int8)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, sizeof(buf), buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_extract_int8(ctx, val), 0);
     EXPECT_EQ(val, -1);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, extract_over_int8)
@@ -161,7 +161,7 @@ TEST(msgbuf, extract_over_int8)
 
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     EXPECT_NE(pldm_msgbuf_extract_int8(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, extract_under_int8)
@@ -175,7 +175,7 @@ TEST(msgbuf, extract_under_int8)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     ctx->remaining = INTMAX_MIN;
     EXPECT_NE(pldm_msgbuf_extract_int8(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, extract_one_uint16)
@@ -188,7 +188,7 @@ TEST(msgbuf, extract_one_uint16)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, sizeof(buf), buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_extract_uint16(ctx, val), 0);
     EXPECT_EQ(val, 0x5aa5);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, extract_under_uint16)
@@ -202,7 +202,7 @@ TEST(msgbuf, extract_under_uint16)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     ctx->remaining = INTMAX_MIN + sizeof(val) - 1;
     EXPECT_NE(pldm_msgbuf_extract_uint16(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, extract_over_uint16)
@@ -214,7 +214,7 @@ TEST(msgbuf, extract_over_uint16)
 
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     EXPECT_NE(pldm_msgbuf_extract_uint16(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, extract_one_int16)
@@ -227,7 +227,7 @@ TEST(msgbuf, extract_one_int16)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, sizeof(buf), buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_extract_int16(ctx, val), 0);
     EXPECT_EQ(val, INT16_MIN);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, extract_over_int16)
@@ -239,7 +239,7 @@ TEST(msgbuf, extract_over_int16)
 
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     EXPECT_NE(pldm_msgbuf_extract_int16(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, extract_under_int16)
@@ -253,7 +253,7 @@ TEST(msgbuf, extract_under_int16)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     ctx->remaining = INTMAX_MIN + sizeof(val) - 1;
     EXPECT_NE(pldm_msgbuf_extract_int16(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, extract_one_uint32)
@@ -266,7 +266,7 @@ TEST(msgbuf, extract_one_uint32)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, sizeof(buf), buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_extract_uint32(ctx, val), 0);
     EXPECT_EQ(val, 0x5a00ffa5);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, extract_over_uint32)
@@ -278,7 +278,7 @@ TEST(msgbuf, extract_over_uint32)
 
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     EXPECT_NE(pldm_msgbuf_extract_uint32(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, extract_under_uint32)
@@ -292,7 +292,7 @@ TEST(msgbuf, extract_under_uint32)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     ctx->remaining = INTMAX_MIN + sizeof(val) - 1;
     EXPECT_NE(pldm_msgbuf_extract_uint32(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, extract_one_int32)
@@ -305,7 +305,7 @@ TEST(msgbuf, extract_one_int32)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, sizeof(buf), buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_extract_int32(ctx, val), 0);
     EXPECT_EQ(val, INT32_MIN);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, extract_over_int32)
@@ -317,7 +317,7 @@ TEST(msgbuf, extract_over_int32)
 
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     EXPECT_NE(pldm_msgbuf_extract_int32(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, extract_under_int32)
@@ -331,7 +331,7 @@ TEST(msgbuf, extract_under_int32)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     ctx->remaining = INTMAX_MIN + sizeof(val) - 1;
     EXPECT_NE(pldm_msgbuf_extract_int32(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, extract_one_real32)
@@ -350,7 +350,7 @@ TEST(msgbuf, extract_one_real32)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, sizeof(buf), buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_extract_real32(ctx, val), 0);
     EXPECT_EQ(val, FLT_MAX);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, extract_over_real32)
@@ -362,7 +362,7 @@ TEST(msgbuf, extract_over_real32)
 
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     EXPECT_NE(pldm_msgbuf_extract_real32(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, extract_under_real32)
@@ -376,7 +376,7 @@ TEST(msgbuf, extract_under_real32)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     ctx->remaining = INTMAX_MIN + sizeof(val) - 1;
     EXPECT_NE(pldm_msgbuf_extract_real32(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, extract_array_uint8_buf0_req0)
@@ -388,7 +388,7 @@ TEST(msgbuf, extract_array_uint8_buf0_req0)
 
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     EXPECT_EQ(pldm_msgbuf_extract_array_uint8(ctx, 0, arr, 0), 0);
-    ASSERT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    ASSERT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, extract_array_uint8_buf1_req1)
@@ -402,7 +402,7 @@ TEST(msgbuf, extract_array_uint8_buf1_req1)
     EXPECT_EQ(
         pldm_msgbuf_extract_array_uint8(ctx, sizeof(arr), arr, sizeof(arr)), 0);
     EXPECT_EQ(arr[0], 0);
-    ASSERT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    ASSERT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, extract_array_uint8_buf1_req2)
@@ -415,7 +415,7 @@ TEST(msgbuf, extract_array_uint8_buf1_req2)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, sizeof(buf)), 0);
     EXPECT_NE(
         pldm_msgbuf_extract_array_uint8(ctx, sizeof(arr), arr, sizeof(arr)), 0);
-    ASSERT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    ASSERT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, extract_under_array_uint8)
@@ -428,7 +428,7 @@ TEST(msgbuf, extract_under_array_uint8)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     ctx->remaining = INTMAX_MIN;
     EXPECT_NE(pldm_msgbuf_extract_array_uint8(ctx, 1, arr, 1), 0);
-    ASSERT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    ASSERT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, extract_array_char_buf0_req0)
@@ -440,7 +440,7 @@ TEST(msgbuf, extract_array_char_buf0_req0)
 
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     EXPECT_EQ(pldm_msgbuf_extract_array_char(ctx, 0, arr, 0), 0);
-    ASSERT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    ASSERT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, extract_array_char_buf1_req1)
@@ -454,7 +454,7 @@ TEST(msgbuf, extract_array_char_buf1_req1)
     EXPECT_EQ(
         pldm_msgbuf_extract_array_char(ctx, sizeof(arr), arr, sizeof(arr)), 0);
     EXPECT_EQ(arr[0], '\0');
-    ASSERT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    ASSERT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, extract_array_char_buf1_req2)
@@ -467,7 +467,7 @@ TEST(msgbuf, extract_array_char_buf1_req2)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, sizeof(buf)), 0);
     EXPECT_NE(
         pldm_msgbuf_extract_array_char(ctx, sizeof(arr), arr, sizeof(arr)), 0);
-    ASSERT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    ASSERT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, extract_under_array_char)
@@ -480,7 +480,7 @@ TEST(msgbuf, extract_under_array_char)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     ctx->remaining = INTMAX_MIN;
     EXPECT_NE(pldm_msgbuf_extract_array_char(ctx, 1, arr, 1), 0);
-    ASSERT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    ASSERT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, consumed_under)
@@ -490,7 +490,7 @@ TEST(msgbuf, consumed_under)
     uint8_t buf[1] = {};
 
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, sizeof(buf)), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy_consumed(ctx), -EBADMSG);
+    EXPECT_EQ(pldm_msgbuf_complete_consumed(ctx), -EBADMSG);
 }
 
 TEST(msgbuf, consumed_exact)
@@ -502,7 +502,7 @@ TEST(msgbuf, consumed_exact)
 
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_extract_uint8(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy_consumed(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete_consumed(ctx), 0);
 }
 
 TEST(msgbuf, consumed_over)
@@ -516,7 +516,7 @@ TEST(msgbuf, consumed_over)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_extract_uint8(ctx, valid), 0);
     EXPECT_NE(pldm_msgbuf_extract_uint8(ctx, invalid), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy_consumed(ctx), -EBADMSG);
+    EXPECT_EQ(pldm_msgbuf_complete_consumed(ctx), -EBADMSG);
 }
 
 TEST(msgbuf, pldm_msgbuf_insert_int32_good)
@@ -537,8 +537,8 @@ TEST(msgbuf, pldm_msgbuf_insert_int32_good)
     EXPECT_EQ(pldm_msgbuf_extract_int32(ctxExtract, checkVal), 0);
 
     EXPECT_EQ(src, checkVal);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, insert_under_int32)
@@ -552,7 +552,7 @@ TEST(msgbuf, insert_under_int32)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     ctx->remaining = INTMAX_MIN + sizeof(val) - 1;
     EXPECT_NE(pldm_msgbuf_insert_int32(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, pldm_msgbuf_insert_uint32_good)
@@ -573,8 +573,8 @@ TEST(msgbuf, pldm_msgbuf_insert_uint32_good)
     EXPECT_EQ(pldm_msgbuf_extract_uint32(ctxExtract, checkVal), 0);
 
     EXPECT_EQ(src, checkVal);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, insert_under_uint32)
@@ -588,7 +588,7 @@ TEST(msgbuf, insert_under_uint32)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     ctx->remaining = INTMAX_MIN + sizeof(val) - 1;
     EXPECT_NE(pldm_msgbuf_insert_uint32(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, pldm_msgbuf_insert_uint16_good)
@@ -609,8 +609,8 @@ TEST(msgbuf, pldm_msgbuf_insert_uint16_good)
     EXPECT_EQ(pldm_msgbuf_extract_uint16(ctxExtract, checkVal), 0);
 
     EXPECT_EQ(src, checkVal);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, insert_under_uint16)
@@ -624,7 +624,7 @@ TEST(msgbuf, insert_under_uint16)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     ctx->remaining = INTMAX_MIN + sizeof(val) - 1;
     EXPECT_NE(pldm_msgbuf_insert_uint16(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, pldm_msgbuf_insert_int16_good)
@@ -645,8 +645,8 @@ TEST(msgbuf, pldm_msgbuf_insert_int16_good)
     EXPECT_EQ(pldm_msgbuf_extract_int16(ctxExtract, checkVal), 0);
 
     EXPECT_EQ(src, checkVal);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, insert_under_int16)
@@ -660,7 +660,7 @@ TEST(msgbuf, insert_under_int16)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     ctx->remaining = INTMAX_MIN + sizeof(val) - 1;
     EXPECT_NE(pldm_msgbuf_insert_int16(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, pldm_msgbuf_insert_uint8_good)
@@ -681,8 +681,8 @@ TEST(msgbuf, pldm_msgbuf_insert_uint8_good)
     EXPECT_EQ(pldm_msgbuf_extract_uint8(ctxExtract, checkVal), 0);
 
     EXPECT_EQ(src, checkVal);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, insert_under_uint8)
@@ -696,7 +696,7 @@ TEST(msgbuf, insert_under_uint8)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     ctx->remaining = INTMAX_MIN + sizeof(val) - 1;
     EXPECT_NE(pldm_msgbuf_insert_uint8(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, pldm_msgbuf_insert_int8_good)
@@ -717,8 +717,8 @@ TEST(msgbuf, pldm_msgbuf_insert_int8_good)
     EXPECT_EQ(pldm_msgbuf_extract_int8(ctxExtract, checkVal), 0);
 
     EXPECT_EQ(src, checkVal);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, insert_under_int8)
@@ -732,7 +732,7 @@ TEST(msgbuf, insert_under_int8)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     ctx->remaining = INTMAX_MIN + sizeof(val) - 1;
     EXPECT_NE(pldm_msgbuf_insert_int8(ctx, val), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, pldm_msgbuf_insert_array_uint8_good)
@@ -756,8 +756,8 @@ TEST(msgbuf, pldm_msgbuf_insert_array_uint8_good)
               0);
 
     EXPECT_EQ(memcmp(src, retBuff, sizeof(retBuff)), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, insert_under_array_uint8)
@@ -772,7 +772,7 @@ TEST(msgbuf, insert_under_array_uint8)
     ctx->remaining = INTMAX_MIN + sizeof(val) - 1;
     EXPECT_NE(
         pldm_msgbuf_insert_array_uint8(ctx, sizeof(val), val, sizeof(val)), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, pldm_msgbuf_insert_array_char_good)
@@ -796,8 +796,8 @@ TEST(msgbuf, pldm_msgbuf_insert_array_char_good)
               0);
 
     EXPECT_EQ(memcmp(src, retBuff, sizeof(retBuff)), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, insert_under_array_char)
@@ -811,7 +811,7 @@ TEST(msgbuf, insert_under_array_char)
     ctx->remaining = INTMAX_MIN + sizeof(val) - 1;
     EXPECT_NE(pldm_msgbuf_insert_array_char(ctx, sizeof(val), val, sizeof(val)),
               0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, pldm_msgbuf_span_required_good)
@@ -838,8 +838,8 @@ TEST(msgbuf, pldm_msgbuf_span_required_good)
               0);
 
     EXPECT_EQ(memcmp(expectData, retBuff, required), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, pldm_msgbuf_span_required_bad)
@@ -863,8 +863,8 @@ TEST(msgbuf, pldm_msgbuf_span_required_bad)
     EXPECT_EQ(pldm_msgbuf_extract_uint16(ctxExtract, testVal), 0);
     EXPECT_EQ(pldm_msgbuf_span_required(ctxExtract, required, NULL), 0);
 
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, span_required_under)
@@ -878,7 +878,7 @@ TEST(msgbuf, span_required_under)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctx, 0, buf, 0), 0);
     ctx->remaining = INTMAX_MIN;
     EXPECT_NE(pldm_msgbuf_span_required(ctx, 1, &cursor), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), -EOVERFLOW);
 }
 
 TEST(msgbuf, pldm_msgbuf_span_string_ascii_good)
@@ -902,7 +902,7 @@ TEST(msgbuf, pldm_msgbuf_span_string_ascii_good)
 
     EXPECT_EQ(required, strlen(retBuff) + 1);
     EXPECT_EQ(strncmp(expectData, retBuff, strlen(retBuff) + 1), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), 0);
 }
 
 TEST(msgbuf, pldm_msgbuf_span_string_ascii_good_with_length)
@@ -930,7 +930,7 @@ TEST(msgbuf, pldm_msgbuf_span_string_ascii_good_with_length)
     EXPECT_EQ(length, strlen(retBuff) + 1);
     EXPECT_EQ(required, length);
     EXPECT_EQ(strncmp(expectData, retBuff, strlen(retBuff) + 1), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), 0);
 }
 
 TEST(msgbuf, pldm_msgbuf_span_string_ascii_allow_null_args)
@@ -944,7 +944,7 @@ TEST(msgbuf, pldm_msgbuf_span_string_ascii_allow_null_args)
     EXPECT_EQ(pldm_msgbuf_extract_uint16(ctxExtract, testVal), 0);
     EXPECT_EQ(0x2211, testVal);
     EXPECT_EQ(pldm_msgbuf_span_string_ascii(ctxExtract, NULL, NULL), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), 0);
 }
 
 TEST(msgbuf, pldm_msgbuf_span_string_ascii_bad_no_terminator)
@@ -960,7 +960,7 @@ TEST(msgbuf, pldm_msgbuf_span_string_ascii_bad_no_terminator)
     EXPECT_EQ(0x2211, testVal);
     EXPECT_EQ(pldm_msgbuf_span_string_ascii(ctxExtract, (void**)&retBuff, NULL),
               -EOVERFLOW);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), -EOVERFLOW);
 }
 
 TEST(msgbuf, pldm_msgbuf_span_string_ascii_under)
@@ -975,7 +975,7 @@ TEST(msgbuf, pldm_msgbuf_span_string_ascii_under)
     ctxExtract->remaining = INTMAX_MIN;
     EXPECT_NE(pldm_msgbuf_span_string_ascii(ctxExtract, (void**)&retBuff, NULL),
               0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), -EOVERFLOW);
 }
 
 static size_t str16len(char16_t* startptr)
@@ -1013,7 +1013,7 @@ TEST(msgbuf, pldm_msgbuf_span_string_utf16_good)
     ASSERT_EQ(0, (uintptr_t)retBuff & (alignof(char16_t) - 1));
     EXPECT_EQ(6, str16len((char16_t*)retBuff) + 1);
     EXPECT_EQ(0, memcmp(expectData, retBuff, sizeof(expectData)));
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), 0);
 }
 
 TEST(msgbuf, pldm_msgbuf_span_string_utf16_good2)
@@ -1059,7 +1059,7 @@ TEST(msgbuf, pldm_msgbuf_span_string_utf16_good2)
     EXPECT_EQ(pldm_msgbuf_extract_uint16(ctxExtract, testVal1), 0);
     EXPECT_EQ(0x1234, testVal1);
 
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), 0);
 }
 
 TEST(msgbuf, pldm_msgbuf_span_string_utf16_allow_null_args)
@@ -1074,7 +1074,7 @@ TEST(msgbuf, pldm_msgbuf_span_string_utf16_allow_null_args)
     EXPECT_EQ(pldm_msgbuf_extract_uint16(ctxExtract, testVal), 0);
     EXPECT_EQ(0x2211, testVal);
     EXPECT_EQ(pldm_msgbuf_span_string_utf16(ctxExtract, NULL, NULL), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), 0);
 }
 
 TEST(msgbuf, pldm_msgbuf_span_string_utf16_bad_no_terminator)
@@ -1091,7 +1091,7 @@ TEST(msgbuf, pldm_msgbuf_span_string_utf16_bad_no_terminator)
     EXPECT_EQ(0x2211, testVal);
     EXPECT_EQ(pldm_msgbuf_span_string_utf16(ctxExtract, (void**)&retBuff, NULL),
               -EOVERFLOW);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), -EOVERFLOW);
 }
 
 TEST(msgbuf, pldm_msgbuf_span_string_utf16_bad_odd_size)
@@ -1108,7 +1108,7 @@ TEST(msgbuf, pldm_msgbuf_span_string_utf16_bad_odd_size)
     EXPECT_EQ(0x2211, testVal);
     EXPECT_EQ(pldm_msgbuf_span_string_utf16(ctxExtract, (void**)&retBuff, NULL),
               -EOVERFLOW);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), -EOVERFLOW);
 }
 
 TEST(msgbuf, pldm_msgbuf_span_string_utf16_mix)
@@ -1178,7 +1178,7 @@ TEST(msgbuf, pldm_msgbuf_span_string_utf16_mix)
     EXPECT_EQ(pldm_msgbuf_extract_uint16(ctxExtract, test_val), 0);
     EXPECT_EQ(0x8877, test_val);
 
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), 0);
 }
 
 TEST(msgbuf, pldm_msgbuf_span_string_utf16_under)
@@ -1193,7 +1193,7 @@ TEST(msgbuf, pldm_msgbuf_span_string_utf16_under)
     ctxExtract->remaining = INTMAX_MIN;
     EXPECT_NE(pldm_msgbuf_span_string_utf16(ctxExtract, (void**)&retBuff, NULL),
               0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), -EOVERFLOW);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), -EOVERFLOW);
 }
 
 TEST(msgbuf, pldm_msgbuf_span_remaining_good)
@@ -1222,8 +1222,8 @@ TEST(msgbuf, pldm_msgbuf_span_remaining_good)
 
     EXPECT_EQ(remaining, sizeof(expectData));
     EXPECT_EQ(memcmp(expectData, retBuff, remaining), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, pldm_msgbuf_span_remaining_bad)
@@ -1244,8 +1244,8 @@ TEST(msgbuf, pldm_msgbuf_span_remaining_bad)
     ASSERT_EQ(pldm_msgbuf_init_errno(ctxExtract, 0, buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_extract_uint16(ctxExtract, testVal), 0);
 
-    EXPECT_EQ(pldm_msgbuf_destroy(ctxExtract), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(ctx), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctxExtract), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(ctx), 0);
 }
 
 TEST(msgbuf, pldm_msgbuf_copy_good)
@@ -1267,8 +1267,8 @@ TEST(msgbuf, pldm_msgbuf_copy_good)
     ASSERT_EQ(pldm_msgbuf_init_errno(dst, sizeof(buf1), buf1, sizeof(buf1)), 0);
     EXPECT_EQ(pldm_msgbuf_extract_uint16(dst, checkVal), 0);
 
-    EXPECT_EQ(pldm_msgbuf_destroy(src), 0);
-    EXPECT_EQ(pldm_msgbuf_destroy(dst), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(src), 0);
+    EXPECT_EQ(pldm_msgbuf_complete(dst), 0);
 
     EXPECT_EQ(buf[0], checkVal);
 }
@@ -1306,8 +1306,8 @@ TEST(msgbuf, pldm_msgbuf_copy_string_ascii_exact)
     ASSERT_EQ(pldm_msgbuf_init_errno(src, 0, msg, sizeof(msg)), 0);
     ASSERT_EQ(pldm_msgbuf_init_errno(dst, 0, buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_copy_string_ascii(dst, src), 0);
-    ASSERT_EQ(pldm_msgbuf_destroy(dst), 0);
-    ASSERT_EQ(pldm_msgbuf_destroy(src), 0);
+    ASSERT_EQ(pldm_msgbuf_complete(dst), 0);
+    ASSERT_EQ(pldm_msgbuf_complete(src), 0);
     EXPECT_EQ(0, memcmp(msg, buf, sizeof(buf)));
 }
 
@@ -1325,8 +1325,8 @@ TEST(msgbuf, pldm_msgbuf_copy_string_ascii_dst_exceeds_src)
     ASSERT_EQ(pldm_msgbuf_init_errno(src, 0, msg, sizeof(msg)), 0);
     ASSERT_EQ(pldm_msgbuf_init_errno(dst, 0, buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_copy_string_ascii(dst, src), 0);
-    ASSERT_EQ(pldm_msgbuf_destroy(dst), 0);
-    ASSERT_EQ(pldm_msgbuf_destroy(src), 0);
+    ASSERT_EQ(pldm_msgbuf_complete(dst), 0);
+    ASSERT_EQ(pldm_msgbuf_complete(src), 0);
     EXPECT_EQ(0, memcmp(buf, msg, sizeof(msg)));
 }
 
@@ -1344,8 +1344,8 @@ TEST(msgbuf, pldm_msgbuf_copy_string_ascii_src_exceeds_dst)
     ASSERT_EQ(pldm_msgbuf_init_errno(src, 0, msg, sizeof(msg)), 0);
     ASSERT_EQ(pldm_msgbuf_init_errno(dst, 0, buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_copy_string_ascii(dst, src), -EOVERFLOW);
-    ASSERT_EQ(pldm_msgbuf_destroy(dst), -EOVERFLOW);
-    ASSERT_EQ(pldm_msgbuf_destroy(src), 0);
+    ASSERT_EQ(pldm_msgbuf_complete(dst), -EOVERFLOW);
+    ASSERT_EQ(pldm_msgbuf_complete(src), 0);
 }
 
 TEST(msgbuf, pldm_msgbuf_copy_string_ascii_unterminated_src)
@@ -1362,8 +1362,8 @@ TEST(msgbuf, pldm_msgbuf_copy_string_ascii_unterminated_src)
     ASSERT_EQ(pldm_msgbuf_init_errno(src, 0, msg, sizeof(msg)), 0);
     ASSERT_EQ(pldm_msgbuf_init_errno(dst, 0, buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_copy_string_ascii(dst, src), -EOVERFLOW);
-    ASSERT_EQ(pldm_msgbuf_destroy(dst), 0);
-    ASSERT_EQ(pldm_msgbuf_destroy(src), -EOVERFLOW);
+    ASSERT_EQ(pldm_msgbuf_complete(dst), 0);
+    ASSERT_EQ(pldm_msgbuf_complete(src), -EOVERFLOW);
 }
 
 TEST(msgbuf, pldm_msgbuf_copy_utf16_exact)
@@ -1380,8 +1380,8 @@ TEST(msgbuf, pldm_msgbuf_copy_utf16_exact)
     ASSERT_EQ(pldm_msgbuf_init_errno(src, 0, msg, sizeof(msg)), 0);
     ASSERT_EQ(pldm_msgbuf_init_errno(dst, 0, buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_copy_string_utf16(dst, src), 0);
-    ASSERT_EQ(pldm_msgbuf_destroy(dst), 0);
-    ASSERT_EQ(pldm_msgbuf_destroy(src), 0);
+    ASSERT_EQ(pldm_msgbuf_complete(dst), 0);
+    ASSERT_EQ(pldm_msgbuf_complete(src), 0);
     EXPECT_EQ(0, memcmp(buf, msg, sizeof(msg)));
 }
 
@@ -1399,8 +1399,8 @@ TEST(msgbuf, pldm_msgbuf_copy_utf16_dst_exceeds_src)
     ASSERT_EQ(pldm_msgbuf_init_errno(src, 0, msg, sizeof(msg)), 0);
     ASSERT_EQ(pldm_msgbuf_init_errno(dst, 0, buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_copy_string_utf16(dst, src), 0);
-    ASSERT_EQ(pldm_msgbuf_destroy(dst), 0);
-    ASSERT_EQ(pldm_msgbuf_destroy(src), 0);
+    ASSERT_EQ(pldm_msgbuf_complete(dst), 0);
+    ASSERT_EQ(pldm_msgbuf_complete(src), 0);
     EXPECT_EQ(0, memcmp(buf, msg, sizeof(msg)));
 }
 
@@ -1418,8 +1418,8 @@ TEST(msgbuf, pldm_msgbuf_copy_utf16_src_exceeds_dst)
     ASSERT_EQ(pldm_msgbuf_init_errno(src, 0, msg, sizeof(msg)), 0);
     ASSERT_EQ(pldm_msgbuf_init_errno(dst, 0, buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_copy_string_utf16(dst, src), -EOVERFLOW);
-    ASSERT_EQ(pldm_msgbuf_destroy(dst), -EOVERFLOW);
-    ASSERT_EQ(pldm_msgbuf_destroy(src), 0);
+    ASSERT_EQ(pldm_msgbuf_complete(dst), -EOVERFLOW);
+    ASSERT_EQ(pldm_msgbuf_complete(src), 0);
 }
 
 TEST(msgbuf, pldm_msgbuf_copy_utf16_unterminated_src)
@@ -1436,6 +1436,6 @@ TEST(msgbuf, pldm_msgbuf_copy_utf16_unterminated_src)
     ASSERT_EQ(pldm_msgbuf_init_errno(src, 0, msg, sizeof(msg)), 0);
     ASSERT_EQ(pldm_msgbuf_init_errno(dst, 0, buf, sizeof(buf)), 0);
     EXPECT_EQ(pldm_msgbuf_copy_string_utf16(dst, src), -EOVERFLOW);
-    ASSERT_EQ(pldm_msgbuf_destroy(dst), 0);
-    ASSERT_EQ(pldm_msgbuf_destroy(src), -EOVERFLOW);
+    ASSERT_EQ(pldm_msgbuf_complete(dst), 0);
+    ASSERT_EQ(pldm_msgbuf_complete(src), -EOVERFLOW);
 }

--- a/tests/msgbuf_generic.c
+++ b/tests/msgbuf_generic.c
@@ -36,7 +36,7 @@ static void test_msgbuf_extract_generic_uint8(void)
     expect(pldm_msgbuf_init_errno(ctx, sizeof(buf), buf, sizeof(buf)) == 0);
     expect(pldm_msgbuf_extract(ctx, val) == 0);
     expect(val == 0xa5);
-    expect(pldm_msgbuf_destroy(ctx) == 0);
+    expect(pldm_msgbuf_complete(ctx) == 0);
 }
 
 static void test_msgbuf_extract_generic_int8(void)
@@ -49,7 +49,7 @@ static void test_msgbuf_extract_generic_int8(void)
     expect(pldm_msgbuf_init_errno(ctx, sizeof(buf), buf, sizeof(buf)) == 0);
     expect(pldm_msgbuf_extract(ctx, val) == 0);
     expect(val == -1);
-    expect(pldm_msgbuf_destroy(ctx) == 0);
+    expect(pldm_msgbuf_complete(ctx) == 0);
 }
 
 static void test_msgbuf_extract_generic_uint16(void)
@@ -62,7 +62,7 @@ static void test_msgbuf_extract_generic_uint16(void)
     expect(pldm_msgbuf_init_errno(ctx, sizeof(buf), buf, sizeof(buf)) == 0);
     expect(pldm_msgbuf_extract(ctx, val) == 0);
     expect(val == 0x5aa5);
-    expect(pldm_msgbuf_destroy(ctx) == 0);
+    expect(pldm_msgbuf_complete(ctx) == 0);
 }
 
 static void test_msgbuf_extract_generic_int16(void)
@@ -75,7 +75,7 @@ static void test_msgbuf_extract_generic_int16(void)
     expect(pldm_msgbuf_init_errno(ctx, sizeof(buf), buf, sizeof(buf)) == 0);
     expect(pldm_msgbuf_extract(ctx, val) == 0);
     expect(val == INT16_MIN);
-    expect(pldm_msgbuf_destroy(ctx) == 0);
+    expect(pldm_msgbuf_complete(ctx) == 0);
 }
 
 static void test_msgbuf_extract_generic_uint32(void)
@@ -88,7 +88,7 @@ static void test_msgbuf_extract_generic_uint32(void)
     expect(pldm_msgbuf_init_errno(ctx, sizeof(buf), buf, sizeof(buf)) == 0);
     expect(pldm_msgbuf_extract(ctx, val) == 0);
     expect(val == 0x5a00ffa5);
-    expect(pldm_msgbuf_destroy(ctx) == 0);
+    expect(pldm_msgbuf_complete(ctx) == 0);
 }
 
 static void test_msgbuf_extract_generic_int32(void)
@@ -101,7 +101,7 @@ static void test_msgbuf_extract_generic_int32(void)
     expect(pldm_msgbuf_init_errno(ctx, sizeof(buf), buf, sizeof(buf)) == 0);
     expect(pldm_msgbuf_extract(ctx, val) == 0);
     expect(val == INT32_MIN);
-    expect(pldm_msgbuf_destroy(ctx) == 0);
+    expect(pldm_msgbuf_complete(ctx) == 0);
 }
 
 static void test_msgbuf_extract_generic_real32(void)
@@ -120,7 +120,7 @@ static void test_msgbuf_extract_generic_real32(void)
     expect(pldm_msgbuf_init_errno(ctx, sizeof(buf), buf, sizeof(buf)) == 0);
     expect(pldm_msgbuf_extract(ctx, val) == 0);
     expect(val == FLT_MAX);
-    expect(pldm_msgbuf_destroy(ctx) == 0);
+    expect(pldm_msgbuf_complete(ctx) == 0);
 }
 
 static void test_msgbuf_extract_array_generic_uint8(void)
@@ -133,7 +133,7 @@ static void test_msgbuf_extract_array_generic_uint8(void)
     expect(pldm_msgbuf_init_errno(ctx, sizeof(buf), buf, sizeof(buf)) == 0);
     expect(pldm_msgbuf_extract_array(ctx, 1, arr, 1) == 0);
     expect(arr[0] == 0);
-    expect(pldm_msgbuf_destroy(ctx) == 0);
+    expect(pldm_msgbuf_complete(ctx) == 0);
 }
 
 static void test_msgbuf_insert_generic_int32(void)
@@ -154,8 +154,8 @@ static void test_msgbuf_insert_generic_int32(void)
     expect(pldm_msgbuf_extract(ctxExtract, checkVal) == 0);
 
     expect(src == checkVal);
-    expect(pldm_msgbuf_destroy(ctxExtract) == 0);
-    expect(pldm_msgbuf_destroy(ctx) == 0);
+    expect(pldm_msgbuf_complete(ctxExtract) == 0);
+    expect(pldm_msgbuf_complete(ctx) == 0);
 }
 
 static void test_msgbuf_insert_generic_uint32(void)
@@ -176,8 +176,8 @@ static void test_msgbuf_insert_generic_uint32(void)
     expect(pldm_msgbuf_extract(ctxExtract, checkVal) == 0);
 
     expect(src == checkVal);
-    expect(pldm_msgbuf_destroy(ctxExtract) == 0);
-    expect(pldm_msgbuf_destroy(ctx) == 0);
+    expect(pldm_msgbuf_complete(ctxExtract) == 0);
+    expect(pldm_msgbuf_complete(ctx) == 0);
 }
 
 static void test_msgbuf_insert_generic_uint16(void)
@@ -198,8 +198,8 @@ static void test_msgbuf_insert_generic_uint16(void)
     expect(pldm_msgbuf_extract(ctxExtract, checkVal) == 0);
 
     expect(src == checkVal);
-    expect(pldm_msgbuf_destroy(ctxExtract) == 0);
-    expect(pldm_msgbuf_destroy(ctx) == 0);
+    expect(pldm_msgbuf_complete(ctxExtract) == 0);
+    expect(pldm_msgbuf_complete(ctx) == 0);
 }
 
 static void test_msgbuf_insert_generic_int16(void)
@@ -220,8 +220,8 @@ static void test_msgbuf_insert_generic_int16(void)
     expect(pldm_msgbuf_extract(ctxExtract, checkVal) == 0);
 
     expect(src == checkVal);
-    expect(pldm_msgbuf_destroy(ctxExtract) == 0);
-    expect(pldm_msgbuf_destroy(ctx) == 0);
+    expect(pldm_msgbuf_complete(ctxExtract) == 0);
+    expect(pldm_msgbuf_complete(ctx) == 0);
 }
 
 static void test_msgbuf_insert_generic_uint8(void)
@@ -242,8 +242,8 @@ static void test_msgbuf_insert_generic_uint8(void)
     expect(pldm_msgbuf_extract(ctxExtract, checkVal) == 0);
 
     expect(src == checkVal);
-    expect(pldm_msgbuf_destroy(ctxExtract) == 0);
-    expect(pldm_msgbuf_destroy(ctx) == 0);
+    expect(pldm_msgbuf_complete(ctxExtract) == 0);
+    expect(pldm_msgbuf_complete(ctx) == 0);
 }
 
 static void test_msgbuf_insert_generic_int8(void)
@@ -264,8 +264,8 @@ static void test_msgbuf_insert_generic_int8(void)
     expect(pldm_msgbuf_extract(ctxExtract, checkVal) == 0);
 
     expect(src == checkVal);
-    expect(pldm_msgbuf_destroy(ctxExtract) == 0);
-    expect(pldm_msgbuf_destroy(ctx) == 0);
+    expect(pldm_msgbuf_complete(ctxExtract) == 0);
+    expect(pldm_msgbuf_complete(ctx) == 0);
 }
 
 static void test_msgbuf_insert_array_generic_uint8(void)
@@ -287,8 +287,8 @@ static void test_msgbuf_insert_array_generic_uint8(void)
                                      sizeof(retBuff)) == 0);
 
     expect(memcmp(src, retBuff, sizeof(retBuff)) == 0);
-    expect(pldm_msgbuf_destroy(ctxExtract) == 0);
-    expect(pldm_msgbuf_destroy(ctx) == 0);
+    expect(pldm_msgbuf_complete(ctxExtract) == 0);
+    expect(pldm_msgbuf_complete(ctx) == 0);
 }
 
 typedef void (*testfn)(void);

--- a/tests/oem/meta/fileio.cpp
+++ b/tests/oem/meta/fileio.cpp
@@ -32,7 +32,7 @@ TEST(DecodeOemMetaFileIoWriteReq, testGoodDecodeRequest)
                                         sizeof(postCode));
     ASSERT_EQ(rc, 0);
 
-    rc = pldm_msgbuf_destroy_consumed(ctx);
+    rc = pldm_msgbuf_complete_consumed(ctx);
     ASSERT_EQ(rc, 0);
 
     constexpr size_t decodedReqLen =
@@ -101,7 +101,7 @@ TEST(DecodeOemMetaFileIoReadReq, testGoodDecodeRequest)
     pldm_msgbuf_insert_uint8(ctx, 1);
     pldm_msgbuf_insert_uint16(ctx, 1223);
 
-    rc = pldm_msgbuf_destroy_consumed(ctx);
+    rc = pldm_msgbuf_complete_consumed(ctx);
     ASSERT_EQ(rc, 0);
 
     struct pldm_oem_meta_file_io_read_req req = {};


### PR DESCRIPTION
This creates a baseline file (and initial responses to any potential secrets found).

After this file is merged, all CI jobs after will run the detect-secrets tool against incoming commits to verify no potential secrets are being shared. If one is found, CI will fail until the .secrets.baseline is updated for the new issue.

See the following for more info:
  https://github.com/IBM/detect-secrets

This PR includes a rebase with upstream in order to get CI to pass (clang-tidy fails).