### PR TITLE
state-set: Add the enum for Presence state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Change categories:
 
 - utils: Introduce `pldm_edac_crc32()`
 - utils: Introduce `pldm_edac_crc8()`
+- state-set: Added the enum pldm_state_set_presence_values
 
 ### Changed
 
@@ -42,7 +43,6 @@ Change categories:
 - requester: Remove related deprecated APIs
 
   Remove all of:
-
   - `pldm_close()`
   - `pldm_open()`
   - `pldm_recv()`
@@ -89,7 +89,6 @@ Change categories:
 
 - Returned error values for the following stable APIs have changed their
   semantics:
-
   - `decode_descriptor_type_length_value()`
   - `decode_event_message_buffer_size_resp()`
   - `decode_get_numeric_effecter_value_resp()`
@@ -105,7 +104,6 @@ Change categories:
   association PDR creation
 
 - Register allocation changed for the following APIs:
-
   - `encode_get_downstream_firmware_parameters_req()`
 
 ### Deprecated

--- a/include/libpldm/state_set.h
+++ b/include/libpldm/state_set.h
@@ -181,6 +181,13 @@ enum pldm_state_set_operational_running_status_values {
 	PLDM_STATE_SET_OPERATIONAL_RUNNING_STATUS_DORMANT = 6
 };
 
+/* @brief List of states for Presence (ID 13).
+ */
+enum pldm_state_set_presence_values {
+	PLDM_STATE_SET_PRESENCE_PRESENT = 1,
+	PLDM_STATE_SET_PRESENCE_NOT_PRESENT = 2,
+};
+
 /* @brief List of states for the Set Identify state (ID 17).
  */
 enum pldm_state_set_identify_state_values {


### PR DESCRIPTION
This commit adds two enum values for Presence state as per the PLDM state set specification DSP0249